### PR TITLE
Update to CMSIS-Compiler 2.0.0 or higher

### DIFF
--- a/AlifSemiconductor.Ensemble.pdsc
+++ b/AlifSemiconductor.Ensemble.pdsc
@@ -886,23 +886,23 @@
     <condition id="Retarget IO STDIN">
       <description>Requirement for Retarget IO STDIN</description>
       <require condition="Ensemble CMSIS_Driver"/>
-	  <require Cclass="Device" Cgroup="SOC Peripherals" Csub="USART"/>
-	  <require Cclass="CMSIS-Compiler" Cgroup="I/O" Csub="STDIN" Cvariant="User"/>
-	</condition>
+      <require Cclass="Device" Cgroup="SOC Peripherals" Csub="USART"/>
+      <require Cclass="CMSIS-Compiler" Cgroup="STDIN" Csub="Custom"/>
+    </condition>
 
     <condition id="Retarget IO STDOUT">
       <description>Requirement for Retarget IO STDOUT</description>
       <require condition="Ensemble CMSIS_Driver"/>
-	  <require Cclass="Device" Cgroup="SOC Peripherals" Csub="USART"/>
-	  <require Cclass="CMSIS-Compiler" Cgroup="I/O" Csub="STDOUT" Cvariant="User"/>
-	</condition>
+      <require Cclass="Device" Cgroup="SOC Peripherals" Csub="USART"/>
+      <require Cclass="CMSIS-Compiler" Cgroup="STDOUT" Csub="Custom"/>
+    </condition>
 
     <condition id="Retarget IO STDERR">
       <description>Requirement for Retarget IO STDERR</description>
       <require condition="Ensemble CMSIS_Driver"/>
-	  <require Cclass="Device" Cgroup="SOC Peripherals" Csub="USART"/>
-	  <require Cclass="CMSIS-Compiler" Cgroup="I/O" Csub="STDERR" Cvariant="User"/>
-	</condition>
+      <require Cclass="Device" Cgroup="SOC Peripherals" Csub="USART"/>
+      <require Cclass="CMSIS-Compiler" Cgroup="STDERR" Csub="Custom"/>
+    </condition>
 
   </conditions>
 <!-- component section -->

--- a/libs/retarget_io/source/stderr_USART.c
+++ b/libs/retarget_io/source/stderr_USART.c
@@ -20,16 +20,16 @@
  ******************************************************************************/
 
 #include "RTE_Components.h"
-#if defined(RTE_Compiler_IO_STDOUT)
-#include "retarget_stdout.h"
-#endif  /* RTE_Compiler_IO_STDOUT */
+#if defined(RTE_CMSIS_Compiler_STDERR)
+#include "retarget_stderr.h"
+#endif  /* RTE_CMSIS_Compiler_STDERR */
 #include CMSIS_device_header
 
 //-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
 
 // <h>STDERR USART Interface
 
-#if defined(RTE_Compiler_IO_STDERR_User)
+#if defined(RTE_CMSIS_Compiler_STDERR_Custom)
 
 /* UART Includes */
 #include "retarget_config.h"
@@ -144,4 +144,4 @@ int stderr_putchar (int ch)
     while (USARTdrv->GetTxCount() != 1);
     return (ch);
 }
-#endif /* defined(RTE_Compiler_IO_STDERR_User) */
+#endif /* defined(RTE_CMSIS_Compiler_STDERR_Custom) */

--- a/libs/retarget_io/source/stdin_USART.c
+++ b/libs/retarget_io/source/stdin_USART.c
@@ -19,9 +19,9 @@
  * @Note     None
  ******************************************************************************/
 
-#if defined(RTE_Compiler_IO_STDIN)
+#if defined(RTE_CMSIS_Compiler_STDIN)
 #include "retarget_stdin.h"
-#endif  /* RTE_Compiler_IO_STDIN */
+#endif  /* RTE_CMSIS_Compiler_STDIN */
 #include <RTE_Components.h>
 #include CMSIS_device_header
 
@@ -29,7 +29,7 @@
 
 // <h>STDIN USART Interface
 
-#if defined(RTE_Compiler_IO_STDIN_User)
+#if defined(RTE_CMSIS_Compiler_STDIN_Custom)
 
 /* UART Includes */
 #include "retarget_config.h"
@@ -141,4 +141,4 @@ int stdin_getchar(void)
     while (USARTdrv->GetRxCount() != 1);
     return (buf[0]);
 }
-#endif  /* defined(RTE_Compiler_IO_STDIN_User)  */
+#endif  /* defined(RTE_CMSIS_Compiler_STDIN_Custom)  */

--- a/libs/retarget_io/source/stdout_USART.c
+++ b/libs/retarget_io/source/stdout_USART.c
@@ -20,16 +20,16 @@
  ******************************************************************************/
 
 #include "RTE_Components.h"
-#if defined(RTE_Compiler_IO_STDOUT)
+#if defined(RTE_CMSIS_Compiler_STDOUT)
 #include "retarget_stdout.h"
-#endif  /* RTE_Compiler_IO_STDOUT */
+#endif  /* RTE_CMSIS_Compiler_STDOUT */
 #include CMSIS_device_header
 
 //-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
 
 // <h>STDOUT USART Interface
 
-#if defined(RTE_Compiler_IO_STDOUT_User)
+#if defined(RTE_CMSIS_Compiler_STDOUT_Custom)
 
 /* UART Includes */
 #include "retarget_config.h"
@@ -144,4 +144,4 @@ int stdout_putchar (int ch)
     while (USARTdrv->GetTxCount() != 1);
     return (ch);
 }
-#endif /* defined(RTE_Compiler_IO_STDOUT_User) */
+#endif /* defined(RTE_CMSIS_Compiler_STDOUT_Custom) */


### PR DESCRIPTION
Updates retarget STDERR/STDIN/STDOUT components to use CMSIS-Compiler 2.0.0.
Components related to stdio were restructured in CMSIS-Compiler from 1.0.0 to 2.0.0 hence new components have to be selected, while source code remains the same - except for the definitions that come from RTE_Components.h.

Note: this breaks existing [DevKit-E7 examples](https://github.com/alifsemi/alif_ensemble-cmsis-dfp/tree/main/Boards/DevKit-e7/Examples) - I can update them too, but lets first agree on current PR content.