### PR TITLE
Update AlifSemiconductor.Ensemble.pdsc

### DIFF
--- a/AlifSemiconductor.Ensemble.pdsc
+++ b/AlifSemiconductor.Ensemble.pdsc
@@ -177,7 +177,7 @@
         <processor Dcore="Cortex-M55" DcoreVersion="r1p0" Dfpu="DP_FPU" Dmpu="MPU" Dmve="FP_MVE" Ddsp="DSP" Dtz="TZ" Dendian="Little-endian" Dclock="400000000" Pname="M55_HP"/>
         <processor Dcore="Cortex-M55" DcoreVersion="r1p0" Dfpu="DP_FPU" Dmpu="MPU" Dmve="FP_MVE" Ddsp="DSP" Dtz="TZ" Dendian="Little-endian" Dclock="160000000" Pname="M55_HE"/>
         <!-- DebugConfig for E8 -->
-        <debugconfig sdf="Debug/SDF/E8/Ensemble E8.sdf" dormant="true"/>
+        <debugconfig sdf="Debug/SDF/E8/Ensemble E8.sdf" dormant="true"/> <!-- File does not exist -->
         <!-- Debug sequences -->
         <sequences>
           <sequence name="DisableWarmResetHandshake" Pname="M55_HP">
@@ -297,7 +297,7 @@
         <processor Dcore="Cortex-M55" DcoreVersion="r1p0" Dfpu="DP_FPU" Dmpu="MPU" Dmve="FP_MVE" Ddsp="DSP" Dtz="TZ" Dendian="Little-endian" Dclock="400000000" Pname="M55_HP"/>
         <processor Dcore="Cortex-M55" DcoreVersion="r1p0" Dfpu="DP_FPU" Dmpu="MPU" Dmve="FP_MVE" Ddsp="DSP" Dtz="TZ" Dendian="Little-endian" Dclock="160000000" Pname="M55_HE"/>
         <!-- DebugConfig for E8 -->
-        <debugconfig sdf="Debug/SDF/E8/Ensemble E8.sdf" dormant="true"/>
+        <debugconfig sdf="Debug/SDF/E8/Ensemble E8.sdf" dormant="true"/> <!-- file does not exist and I would expect E4/Ensemble E4.sdf which does not exist either --> 
         <!-- Debug sequences -->
         <sequences>
           <sequence name="DisableWarmResetHandshake" Pname="M55_HP">

--- a/AlifSemiconductor.Ensemble.pdsc
+++ b/AlifSemiconductor.Ensemble.pdsc
@@ -1423,11 +1423,11 @@
       <book category="overview"  name="https://alifsemi.com/support/kits/ai-ml-appkit/" title="Ensemble AI/ML AppKit Gen 2 Web Page"/>
       <mountedDevice deviceIndex="0" Dvendor="Alif Semiconductor:165" Dname="AE722F80F55D5LS"/>
       <compatibleDevice deviceIndex="0" Dvendor="Alif Semiconductor:165" Dname="AE512F80F55D5LS"/>
-      <compatibleDevice deviceIndex="1" Dvendor="Alif Semiconductor:165" Dname="AE512F80F5582LS"/>
-      <compatibleDevice deviceIndex="2" Dvendor="Alif Semiconductor:165" Dname="AE302F80F55D5LE"/>
-      <compatibleDevice deviceIndex="3" Dvendor="Alif Semiconductor:165" Dname="AE302F80F5582LE"/>
-      <compatibleDevice deviceIndex="4" Dvendor="Alif Semiconductor:165" Dname="AE302F80C1557LE"/>
-      <compatibleDevice deviceIndex="5" Dvendor="Alif Semiconductor:165" Dname="AE302F40C1537LE"/>
+      <compatibleDevice deviceIndex="0" Dvendor="Alif Semiconductor:165" Dname="AE512F80F5582LS"/>
+      <compatibleDevice deviceIndex="0" Dvendor="Alif Semiconductor:165" Dname="AE302F80F55D5LE"/>
+      <compatibleDevice deviceIndex="0" Dvendor="Alif Semiconductor:165" Dname="AE302F80F5582LE"/>
+      <compatibleDevice deviceIndex="0" Dvendor="Alif Semiconductor:165" Dname="AE302F80C1557LE"/>
+      <compatibleDevice deviceIndex="0" Dvendor="Alif Semiconductor:165" Dname="AE302F40C1537LE"/>
       <debugInterface adapter="JTAG/SW" connector="20-pin Arm Coresight JTAG Connector (1.27 mm)"/>
       <debugInterface adapter="JTAG/SW" connector="10-pin Arm Coresight JTAG Connector (1.27 mm)"/>
       <feature type="XTAL" n="38400000"/>

--- a/AlifSemiconductor.Ensemble.pdsc
+++ b/AlifSemiconductor.Ensemble.pdsc
@@ -1295,11 +1295,11 @@
       <book category="overview"  name="https://alifsemi.com/support/kits/ensemble-devkit-gen2/" title="Ensemble DevKit Gen 2 Web Page"/>
       <mountedDevice deviceIndex="0" Dvendor="Alif Semiconductor:165" Dname="AE722F80F55D5LS"/>
       <compatibleDevice deviceIndex="0" Dvendor="Alif Semiconductor:165" Dname="AE512F80F55D5LS"/>
-      <compatibleDevice deviceIndex="1" Dvendor="Alif Semiconductor:165" Dname="AE512F80F5582LS"/>
-      <compatibleDevice deviceIndex="2" Dvendor="Alif Semiconductor:165" Dname="AE302F80F55D5LE"/>
-      <compatibleDevice deviceIndex="3" Dvendor="Alif Semiconductor:165" Dname="AE302F80F5582LE"/>
-      <compatibleDevice deviceIndex="4" Dvendor="Alif Semiconductor:165" Dname="AE302F80C1557LE"/>
-      <compatibleDevice deviceIndex="5" Dvendor="Alif Semiconductor:165" Dname="AE302F40C1537LE"/>
+      <compatibleDevice deviceIndex="0" Dvendor="Alif Semiconductor:165" Dname="AE512F80F5582LS"/>
+      <compatibleDevice deviceIndex="0" Dvendor="Alif Semiconductor:165" Dname="AE302F80F55D5LE"/>
+      <compatibleDevice deviceIndex="0" Dvendor="Alif Semiconductor:165" Dname="AE302F80F5582LE"/>
+      <compatibleDevice deviceIndex="0" Dvendor="Alif Semiconductor:165" Dname="AE302F80C1557LE"/>
+      <compatibleDevice deviceIndex="0" Dvendor="Alif Semiconductor:165" Dname="AE302F40C1537LE"/>
       <debugInterface adapter="JTAG/SW" connector="20-pin Arm Coresight JTAG Connector (1.27 mm)"/>
       <debugInterface adapter="JTAG/SW" connector="10-pin Arm Coresight JTAG Connector (1.27 mm)"/>
       <feature type="XTAL" n="38400000"/>
@@ -1342,10 +1342,8 @@
       <!--book category="overview"  name="https://alifsemi.com/support/kits/eagle-devkit-gen1/" title="Eagle DevKit Gen 1 Web Page"/-->
       <mountedDevice deviceIndex="0" Dvendor="Alif Semiconductor:165" Dname="AE822FA0E5597LS0" />
       <compatibleDevice deviceIndex="0" Dvendor="Alif Semiconductor:165" Dname="AE822FA0E5597BS0"/>
-      <compatibleDevice deviceIndex="1" Dvendor="Alif Semiconductor:165" Dname="AE612FA0E5597BS0"/>
-      <compatibleDevice deviceIndex="2" Dvendor="Alif Semiconductor:165" Dname="AE612FA0E5597LS0"/>
-      <compatibleDevice deviceIndex="3" Dvendor="Alif Semiconductor:165" Dname="AE402FA0E5597BE0"/>
-      <compatibleDevice deviceIndex="4" Dvendor="Alif Semiconductor:165" Dname="AE402FA0E5597LE0"/>
+      <compatibleDevice deviceIndex="0" Dvendor="Alif Semiconductor:165" Dname="AE402FA0E5597BE0"/>
+      <compatibleDevice deviceIndex="0" Dvendor="Alif Semiconductor:165" Dname="AE402FA0E5597LE0"/>
       <debugInterface adapter="JTAG/SW" connector="20-pin Arm Coresight JTAG Connector (1.27 mm)"/>
       <debugInterface adapter="JTAG/SW" connector="10-pin Arm Coresight JTAG Connector (1.27 mm)"/>
       <feature type="XTAL" n="38400000"/>
@@ -1386,14 +1384,6 @@
       <description>Development Kit E1C</description>
       <!--book category="overview"  name="https://alifsemi.com/support/kits/ensemble-devkit-gen2/" title=" DevKit Gen 2 Web Page"/-->
       <mountedDevice deviceIndex="0" Dvendor="Alif Semiconductor:165" Dname="AE1C1F4051920PH"  />
-      <compatibleDevice deviceIndex="0" Dvendor="Alif Semiconductor:165" Dname="AE1C1F4051920HH"/>
-      <compatibleDevice deviceIndex="1" Dvendor="Alif Semiconductor:165" Dname="AE1C1F40319205H"/>
-      <compatibleDevice deviceIndex="2" Dvendor="Alif Semiconductor:165" Dname="AE1C1F1041010PH"/>
-      <compatibleDevice deviceIndex="3" Dvendor="Alif Semiconductor:165" Dname="AE1C1F1041010HH"/>
-      <compatibleDevice deviceIndex="4" Dvendor="Alif Semiconductor:165" Dname="AE1C1F10410105H"/>
-      <compatibleDevice deviceIndex="5" Dvendor="Alif Semiconductor:165" Dname="AE1C1F1040505HH"/>
-      <compatibleDevice deviceIndex="6" Dvendor="Alif Semiconductor:165" Dname="AE1C1F1040505PH"/>
-      <compatibleDevice deviceIndex="7" Dvendor="Alif Semiconductor:165" Dname="AE1C1F104050525H"/>
       <debugInterface adapter="JTAG/SW" connector="20-pin Arm Coresight JTAG Connector (1.27 mm)"/>
       <debugInterface adapter="JTAG/SW" connector="10-pin Arm Coresight JTAG Connector (1.27 mm)"/>
       <feature type="XTAL" n="38400000"/>
@@ -1518,10 +1508,12 @@
       <accept Pname="M55_HP" Dname="AE402FA0*"/>
     </condition>
 
-    <condition id="CMSIS-Core">
+    <condition id="Ensemble CMSIS-Core">
       <description>Generic Alif Semiconductor M55_HP and M55_HE device startup and depends on CMSIS Core</description>
+      <require condition="Ensemble"/>
       <require Cclass="CMSIS" Cgroup="CORE"/>
     </condition>
+
     <condition id="Ensemble">
       <description>Alif Semiconductor Ensemble Series devices</description>
       <require Dvendor="Alif Semiconductor:165"/>
@@ -1830,7 +1822,7 @@
   </conditions>
 <!-- component section -->
   <components>
-    <component Cclass="Device" Cgroup="Startup" Cversion="2.0.0" condition="CMSIS-Core">
+    <component Cclass="Device" Cgroup="Startup" Cversion="2.0.0" condition="Ensemble CMSIS-Core">
       <description>System and Startup file for M55_HP, M55_HP and SOC </description>
       <files>
         <!-- include folder / device header file -->
@@ -2027,7 +2019,7 @@
        </files>
      </component>
 
-<!-- Driver components  -->
+    <!-- Driver components  -->
     <component Cclass="CMSIS Driver" Cgroup="GPIO" Cversion="1.0.0" Capiversion="1.0.0" condition="Ensemble CMSIS_Driver">
       <description>GPIO driver for Alif Semiconductor SOC</description>
       <RTE_Components_h>
@@ -2863,7 +2855,7 @@
     </component>
 
 
-    <component Cclass="BSP" Cgroup="Board Config" Cversion="2.0.0">
+    <component Cclass="BSP" Cgroup="Board Config" Cversion="2.0.0" condition="Ensemble">
       <description>Conductor Tool based board configuration for Board Config</description>
       <files>
         <file category="source" name="libs/board_config/board_config.c"/>


### PR DESCRIPTION
Adding hardware specific filter condition to Device:Startup and BSP:Board Config components to avoid these components showing for all other devices/boards

Removed "compatibleDevices" from boards that are not described as part of the `<devices>` section.