### PR TITLE
PDSC: remove "DisableWarmResetHandshake" sequence functionality

### DIFF
--- a/AlifSemiconductor.Ensemble.pdsc
+++ b/AlifSemiconductor.Ensemble.pdsc
@@ -205,15 +205,7 @@
         <debugconfig dormant="true"/>
         <!-- Debug sequences -->
         <sequences>
-          <sequence name="DisableWarmResetHandshake" Pname="M55_HP">
-            <block>
-              Write32(0x1A600024, 0);
-            </block>
-          </sequence>
-          <sequence name="DisableWarmResetHandshake" Pname="M55_HE">
-            <block>
-              Write32(0x1A601024, 0);
-            </block>
+          <sequence name="DisableWarmResetHandshake">
           </sequence>
         </sequences>
         <!-- On-chip NVM Region -->


### PR DESCRIPTION
This enables out of the box debugging using J-Link and CMSIS-DAP adapters with CMSIS Debugger extension for VS Code.