### PR TITLE
DFP pack pdsc file update request

### DIFF
--- a/AlifSemiconductor.Ensemble.pdsc
+++ b/AlifSemiconductor.Ensemble.pdsc
@@ -2618,6 +2618,7 @@
 		<file category="header" name="drivers/include/sys_ctrl_adc.h"/>
 		<file category="header" name="Alif_CMSIS/Include/config/analog_config.h" version="2.0.4" attr="config"/>
 		<file category="header" name="drivers/include/sys_ctrl_analog.h"/>
+    <file category="source" name="drivers/source/sys_ctrl_analog.c"/>
 	  </files>
     </component>
 


### PR DESCRIPTION
sys_ctrl_analog.c needs to be added to the .pdsc file under ADC component. This file is necessary for the demo_adc.c to build.