### PR TITLE
PDSC: Replace "CoreOther" device features with dedicated "NPU" feature entries

### DIFF
--- a/AlifSemiconductor.Ensemble.pdsc
+++ b/AlifSemiconductor.Ensemble.pdsc
@@ -247,9 +247,9 @@
         <feature type="PowerOther" n="1" name="BOR"/>
         <!--Security-->
         <feature type="CoreOther" n="1" name="Full Secure Enclave"/>
-        <feature type="CoreOther" n="1" name="Neural Processing Unit (NPU) Ethos-U55 HP"/>
-        <feature type="CoreOther" n="1" name="Neural Processing Unit (NPU) Ethos-U55 HE"/>
-        <feature type="CoreOther" n="1"  name="Neural Processing Unit (NPU) Ethos-U85"/>
+        <feature type="NPU" n="Ethos-U55 (HP)" m="256MACs"/>
+        <feature type="NPU" n="Ethos-U55 (HE)" m="128MACs"/>
+        <feature type="NPU" n="Ethos-U85" m="256MACs"/>
         <feature type="CoreOther" n="2" name="CRC Calculation Unit"/>
         <!--External Memory-->
         <feature type="ComOther" n="2" name="Cryptographic Octal SPI (OSPI)"/>
@@ -368,9 +368,9 @@
         <feature type="PowerOther" n="1" name="BOR"/>
         <!--Security-->
         <feature type="CoreOther" n="1" name="Full Secure Enclave"/>
-        <feature type="CoreOther" n="1" name="Neural Processing Unit (NPU) Ethos-U55 HP"/>
-        <feature type="CoreOther" n="1" name="Neural Processing Unit (NPU) Ethos-U55 HE"/>
-        <feature type="CoreOther" n="1"  name="Neural Processing Unit (NPU) Ethos-U85"/>
+        <feature type="NPU" n="Ethos-U55 (HP)" m="256MACs"/>
+        <feature type="NPU" n="Ethos-U55 (HE)" m="128MACs"/>
+        <feature type="NPU" n="Ethos-U85" m="256MACs"/>
         <feature type="CoreOther" n="2" name="CRC Calculation Unit"/>
         <!--External Memory-->
         <feature type="ComOther" n="2" name="Cryptographic Octal SPI (OSPI)"/>
@@ -489,9 +489,9 @@
         <feature type="PowerOther" n="1" name="BOR"/>
         <!--Security-->
         <feature type="CoreOther" n="1" name="Full Secure Enclave"/>
-        <feature type="CoreOther" n="1" name="Neural Processing Unit (NPU) Ethos-U55 HP"/>
-        <feature type="CoreOther" n="1" name="Neural Processing Unit (NPU) Ethos-U55 HE"/>
-        <feature type="CoreOther" n="1"  name="Neural Processing Unit (NPU) Ethos-U85"/>
+        <feature type="NPU" n="Ethos-U55 (HP)" m="256MACs"/>
+        <feature type="NPU" n="Ethos-U55 (HE)" m="128MACs"/>
+        <feature type="NPU" n="Ethos-U85" m="256MACs"/>
         <feature type="CoreOther" n="2" name="CRC Calculation Unit"/>
         <!--External Memory-->
         <feature type="ComOther" n="2" name="Cryptographic Octal SPI (OSPI)"/>
@@ -619,8 +619,8 @@
         <feature type="PowerOther" n="1" name="BOR"/>
         <!--Security-->
         <feature type="CoreOther" n="1" name="Full Secure Enclave"/>
-        <feature type="CoreOther" n="1" name="Neural Processing Unit (NPU) Ethos-U55 HP"/>
-        <feature type="CoreOther" n="1" name="Neural Processing Unit (NPU) Ethos-U55 HE"/>
+        <feature type="NPU" n="Ethos-U55 (HP)" m="256MACs"/>
+        <feature type="NPU" n="Ethos-U55 (HE)" m="128MACs"/>
         <feature type="CoreOther" n="2" name="CRC Calculation Unit"/>
         <!--External Memory-->
         <feature type="ComOther" n="2" name="Cryptographic Octal SPI (OSPI)"/>
@@ -732,8 +732,8 @@
         <feature type="PowerOther" n="1" name="BOR"/>
         <!--Security-->
         <feature type="CoreOther" n="1" name="Full Secure Enclave"/>
-        <feature type="CoreOther" n="1" name="Neural Processing Unit (NPU) Ethos-U55 HP"/>
-        <feature type="CoreOther" n="1" name="Neural Processing Unit (NPU) Ethos-U55 HE"/>
+        <feature type="NPU" n="Ethos-U55 (HP)" m="256MACs"/>
+        <feature type="NPU" n="Ethos-U55 (HE)" m="128MACs"/>
         <feature type="CoreOther" n="2" name="CRC Calculation Unit"/>
         <!--External Memory-->
         <feature type="ComOther" n="2" name="Cryptographic Octal SPI (OSPI)"/>
@@ -886,7 +886,7 @@
         <feature type="PowerOther" n="1" name="BOR"/>
         <!--Security-->
         <feature type="CoreOther" n="1" name="Full Secure Enclave"/>
-        <feature type="CoreOther" n="1" name="Neural Processing Unit (NPU) Ethos-U55 HE"/>
+        <feature type="NPU" n="Ethos-U55 (HE)" m="128MACs"/>
         <feature type="CoreOther" n="2" name="CRC Calculation Unit"/>
         <!--External Memory-->
         <feature type="ComOther" n="2" name="Cryptographic Octal SPI (OSPI)"/>
@@ -971,7 +971,7 @@
           <debug svd="Debug/SVD/AE302F80F55D5AE_CM55_HP_View.svd" Pname="M55_HP" __apid="0"/>
           <debug svd="Debug/SVD/AE302F80F55D5AE_CM55_HE_View.svd" Pname="M55_HE" __apid="1"/>
           <feature type="CSP" n="208" name="WLCSP Package"/>
-          <feature type="CoreOther" n="1" name="Neural Processing Unit (NPU) Ethos-U55 HP"/>
+          <feature type="NPU" n="Ethos-U55 (HP)" m="256MACs"/>
           <feature type="CAN" n="1"  name="CAN-FD Controller"/>
         </device>
        <device Dname="AE302F80F5582AE">
@@ -1006,7 +1006,7 @@
           <debug svd="Debug/SVD/AE302F80F5582AE_CM55_HP_View.svd" Pname="M55_HP" __apid="0"/>
           <debug svd="Debug/SVD/AE302F80F5582AE_CM55_HE_View.svd" Pname="M55_HE" __apid="1"/>
           <feature type="CSP" n="208" name="WLCSP Package"/>
-          <feature type="CoreOther" n="1" name="Neural Processing Unit (NPU) Ethos-U55 HP"/>
+          <feature type="NPU" n="Ethos-U55 (HP)" m="256MACs"/>
           <feature type="CAN" n="1"  name="CAN-FD Controller"/>
         </device>
 
@@ -1047,7 +1047,7 @@
           <debug svd="Debug/SVD/AE302F80F55D5LE_CM55_HP_View.svd" Pname="M55_HP" __apid="0"/>
           <debug svd="Debug/SVD/AE302F80F55D5LE_CM55_HE_View.svd" Pname="M55_HE" __apid="1"/>
           <feature type="BGA" n="194" name="FBGA Package"/>
-          <feature type="CoreOther" n="1" name="Neural Processing Unit (NPU) Ethos-U55 HP"/>
+          <feature type="NPU" n="Ethos-U55 (HP)" m="256MACs"/>
           <feature type="CAN" n="1"  name="CAN-FD Controller"/>
         </device>
 
@@ -1083,7 +1083,7 @@
           <debug svd="Debug/SVD/AE302F80F5582LE_CM55_HP_View.svd" Pname="M55_HP" __apid="0"/>
           <debug svd="Debug/SVD/AE302F80F5582LE_CM55_HE_View.svd" Pname="M55_HE" __apid="1"/>
           <feature type="BGA" n="194" name="FBGA Package"/>
-          <feature type="CoreOther" n="1" name="Neural Processing Unit (NPU) Ethos-U55 HP"/>
+          <feature type="NPU" n="Ethos-U55 (HP)" m="256MACs"/>
           <feature type="CAN" n="1"  name="CAN-FD Controller"/>
         </device>
 
@@ -1105,7 +1105,7 @@
           <debug svd="Debug/SVD/AE302F80C1557LE_CM55_HP_View.svd" Pname="M55_HP" __apid="0"/>
           <debug svd="Debug/SVD/AE302F80C1557LE_CM55_HE_View.svd" Pname="M55_HE" __apid="1"/>
           <feature type="BGA" n="194" name="FBGA Package"/>
-          <feature type="CoreOther" n="1" name="Neural Processing Unit (NPU) Ethos-U55 HP"/>
+          <feature type="NPU" n="Ethos-U55 (HP)" m="256MACs"/>
         </device>
 	<device Dname="AE302F40C1537LE">
 	    <!-- DebugConfig for E3(1.5MiB MRAM) -->
@@ -1213,7 +1213,7 @@
           <compile Pname="M55_HE" header="Device/core/common/include/alif.h" define="RTSS_HE"/>
           <debug svd="Debug/SVD/AE101F4071542LH_CM55_HE_View.svd" Pname="M55_HE" __apid="1"/>
           <feature type="BGA" n="194" name="FBGA Package"/>
-          <feature type="CoreOther" n="1" name="Neural Processing Unit (NPU) Ethos-U55 HE"/>
+          <feature type="NPU" n="Ethos-U55 (HE)" m="128MACs"/>
           <feature type="CAN" n="1" name="CAN-FD Controller"/>
           <feature type="Other" n="1" name="2D Graphics Processing Unit (GPU2D)"/>
           <feature type="GLCD" n="1" m="1280.800" name="Display Parallel Interface"/>
@@ -1308,7 +1308,7 @@
           <compile Pname="M55_HE" header="Device/core/common/include/alif.h" define="RTSS_HE"/>
           <debug Pname="M55_HE" __apid="1"/>
           <feature type="BGA" n="194" name="FBGA Package"/>
-          <feature type="CoreOther" n="1" name="Neural Processing Unit (NPU) Ethos-U55 HE"/>
+          <feature type="NPU" n="Ethos-U55 (HE)" m="128MACs"/>
           <feature type="CAN" n="2" name="CAN-FD Controller"/>
           <feature type="Other" n="1" name="2D Graphics Processing Unit (GPU2D)"/>
           <feature type="GLCD" n="1" m="1280.800" name="Display Parallel Interface"/>


### PR DESCRIPTION
This aligns the [feature description ](https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/pdsc_family_pg.html) with the Open-CMSIS-Pack specification for the <feature> element.