### PR TITLE
drivers: i3c: get current xfer data count

### DIFF
--- a/Alif_CMSIS/Include/Driver_I3C.h
+++ b/Alif_CMSIS/Include/Driver_I3C.h
@@ -16,7 +16,7 @@ extern "C" {
 
 #include "Driver_Common.h"
 
-#define ARM_I3C_API_VERSION     ARM_DRIVER_VERSION_MAJOR_MINOR(7, 2) /* API version */
+#define ARM_I3C_API_VERSION     ARM_DRIVER_VERSION_MAJOR_MINOR(8, 0) /* API version */
 
 /****** I3C Control Codes *****/
 
@@ -176,10 +176,11 @@ typedef struct _ARM_I3C_CMD {
 typedef struct _ARM_I3C_STATUS {
     uint32_t busy           : 1;  ///< Busy flag
     uint32_t mode           : 1;  ///< Mode: 0=Slave, 1=Master
+    uint32_t direction      : 1;  ///< Direction: 0=Transmitter, 1=Receiver
     uint32_t ibi_slv_addr   : 8;  ///< Address of last IBI slave
     uint32_t last_error_code: 4;  ///< Last occurred error
     uint32_t defslv_cnt: 8;  ///< Slave count from last DEFSLVS (Applicable for Sec masters only)
-    uint32_t reserved  : 10;
+    uint32_t reserved       : 9;
 } ARM_I3C_STATUS;
 
 /**
@@ -374,6 +375,7 @@ typedef struct _ARM_DRIVER_I3C {
     (void);  ///< Pointer to \ref GetCapabilities   : Get I3C driver capabilities.
     ARM_I3C_STATUS (*GetStatus)
     (void);  ///< Pointer to \ref GetStatus         : Get I3C driver status.
+    int32_t (*GetDataCount) (void);  ///< Pointer to \ref GetDataCount: Get transferred data count.
     ARM_I3C_DEVICE_INFO (*GetDeviceInfo)
     (void);  ///< Pointer to \ref GetDeviceInfo     : Get I3C device information.
     int32_t (*Initialize)(ARM_I3C_SignalEvent_t cb_event);  ///< Pointer to \ref Initialize        :

--- a/Alif_CMSIS/Source/Driver_I3C.c
+++ b/Alif_CMSIS/Source/Driver_I3C.c
@@ -27,7 +27,7 @@
 #error "I3C is not enabled in the RTE_Device.h"
 #endif
 
-#define ARM_I3C_DRV_VERSION ARM_DRIVER_VERSION_MAJOR_MINOR(7, 14) /* driver version */
+#define ARM_I3C_DRV_VERSION ARM_DRIVER_VERSION_MAJOR_MINOR(8, 0) /* driver version */
 
 #if I3C_DMA_ENABLE
 /* DMA helper macros */
@@ -1053,6 +1053,48 @@ static ARM_I3C_STATUS I3Cx_GetStatus(I3C_RESOURCES *i3c)
 }
 
 /**
+  \fn      int32_t I3Cx_GetDataCount(I3C_RESOURCES *i3c)
+  \brief   Get transferred data count.
+  \param   i3c   : Pointer to i3c resources structure
+  \retval  transfer data count
+*/
+static int32_t I3Cx_GetDataCount(I3C_RESOURCES *i3c)
+{
+    int32_t count = 0;
+    if (i3c->status.busy) {
+#if I3C_DMA_ENABLE
+        if (i3c->dma_enable) {
+            uint32_t dma_count = 0;
+            ARM_DRIVER_DMA *dma_drv;
+            DMA_Handle_Type *handle;
+
+            if (i3c->status.direction == I3C_DIR_TRANSMITTER) {
+                dma_drv = i3c->dma_cfg->dma_tx.dma_drv;
+                handle  = (DMA_Handle_Type *)&i3c->dma_cfg->dma_tx.dma_handle;
+                (void) dma_drv->GetStatus(handle, &dma_count);
+                /* TX DMA transfers 8-bit bytes */
+                count = (int32_t) dma_count;
+            } else {
+                dma_drv = i3c->dma_cfg->dma_rx.dma_drv;
+                handle  = (DMA_Handle_Type *)&i3c->dma_cfg->dma_rx.dma_handle;
+                (void) dma_drv->GetStatus(handle, &dma_count);
+                /* RX DMA transfers 8-bit bytes */
+                count = (int32_t) dma_count;
+            }
+        } else
+#endif
+        {
+            if (i3c->status.direction == I3C_DIR_TRANSMITTER) {
+                count = (int32_t)i3c->xfer.tx_cur_cnt;
+            } else {
+                count = (int32_t)i3c->xfer.rx_cur_cnt;
+            }
+        }
+    }
+    return count;
+}
+
+/**
   \fn           ARM_I3C_DEVICE_INFO I3Cx_GetDeviceInfo(I3C_RESOURCES *i3c)
   \brief        Get i3c device information
   \return       i3c driver info
@@ -1147,6 +1189,7 @@ static int I3Cx_MasterSendCommand(I3C_RESOURCES *i3c, ARM_I3C_CMD *ccc)
         i3c->xfer.xfer_cmd.addr_depth = 1U;
         i3c->xfer.xfer_cmd.def_byte   = ccc->def_byte;
         i3c->xfer.xfer_cmd.data_len   = ccc->len;
+        i3c->status.direction         = I3C_DIR_RECEIVER;
 
 #if RTE_I3C_BLOCKING_MODE_ENABLE
         if (i3c->blocking_mode) {
@@ -1187,6 +1230,7 @@ static int I3Cx_MasterSendCommand(I3C_RESOURCES *i3c, ARM_I3C_CMD *ccc)
             i3c->xfer.xfer_cmd.addr_depth = 1U;
             i3c->xfer.xfer_cmd.def_byte   = ccc->def_byte;
             i3c->xfer.xfer_cmd.data_len   = ccc->len;
+            i3c->status.direction         = I3C_DIR_TRANSMITTER;
 
 #if RTE_I3C_BLOCKING_MODE_ENABLE
             if (i3c->blocking_mode) {
@@ -1271,6 +1315,7 @@ static int I3Cx_MasterTransmit(I3C_RESOURCES *i3c, uint8_t addr, const uint8_t *
     }
 
     i3c->status.busy              = 1;
+    i3c->status.direction         = I3C_DIR_TRANSMITTER;
     i3c->xfer.error               = 0U;
     i3c->xfer.tx_len              = len;
     i3c->xfer.rx_buf              = NULL;
@@ -1371,6 +1416,7 @@ static int I3Cx_MasterReceive(I3C_RESOURCES *i3c, uint8_t addr, uint8_t *data, u
     }
 
     i3c->status.busy              = 1;
+    i3c->status.direction         = I3C_DIR_RECEIVER;
     i3c->xfer.error               = 0U;
     i3c->xfer.tx_buf              = NULL;
     i3c->xfer.tx_len              = 0U;
@@ -1467,6 +1513,7 @@ static int I3Cx_SlaveTransmit(I3C_RESOURCES *i3c, const uint8_t *data, uint16_t 
     }
 
     i3c->status.busy            = 1;
+    i3c->status.direction       = I3C_DIR_TRANSMITTER;
     i3c->xfer.error             = 0U;
     i3c->xfer.rx_buf            = NULL;
     i3c->xfer.rx_len            = 0U;
@@ -1560,6 +1607,7 @@ static int I3Cx_SlaveReceive(I3C_RESOURCES *i3c, uint8_t *data, uint32_t len)
     }
 
     i3c->status.busy            = 1;
+    i3c->status.direction       = I3C_DIR_RECEIVER;
     i3c->xfer.error             = 0U;
     i3c->xfer.tx_buf            = NULL;
     i3c->xfer.tx_len            = 0;
@@ -1747,6 +1795,7 @@ static int I3Cx_MasterAssignDA(I3C_RESOURCES *i3c, ARM_I3C_CMD *addr_cmd)
     }
 
     i3c->status.busy            = 1U;
+    i3c->status.direction       = I3C_DIR_TRANSMITTER;
     i3c->xfer.error             = 0U;
     i3c->xfer.rx_len            = 0U;
     i3c->xfer.rx_cur_cnt        = 0U;
@@ -2707,6 +2756,10 @@ static ARM_I3C_STATUS I3C_GetStatus(void)
     return I3Cx_GetStatus(&i3c);
 }
 
+static int32_t I3C_GetDataCount(void)
+{
+    return I3Cx_GetDataCount(&i3c);
+}
 static ARM_I3C_DEVICE_INFO I3C_GetDeviceInfo(void)
 {
     return I3Cx_GetDeviceInfo(&i3c);
@@ -2793,6 +2846,7 @@ ARM_DRIVER_I3C        Driver_I3C = {
     I3C_GetVersion,
     I3C_GetCapabilities,
     I3C_GetStatus,
+    I3C_GetDataCount,
     I3C_GetDeviceInfo,
     I3C_Initialize,
     I3C_Uninitialize,
@@ -2895,6 +2949,11 @@ static ARM_I3C_STATUS LPI3C_GetStatus(void)
     return I3Cx_GetStatus(&LPI3C_RES);
 }
 
+static int32_t LPI3C_GetDataCount(void)
+{
+    return I3Cx_GetDataCount(&LPI3C_RES);
+}
+
 static ARM_I3C_DEVICE_INFO LPI3C_GetDeviceInfo(void)
 {
     return I3Cx_GetDeviceInfo(&LPI3C_RES);
@@ -2981,6 +3040,7 @@ ARM_DRIVER_I3C        Driver_I3CLP = {
     I3C_GetVersion,
     I3C_GetCapabilities,
     LPI3C_GetStatus,
+    LPI3C_GetDataCount,
     LPI3C_GetDeviceInfo,
     LPI3C_Initialize,
     LPI3C_Uninitialize,

--- a/Alif_CMSIS/Source/Driver_I3C.c
+++ b/Alif_CMSIS/Source/Driver_I3C.c
@@ -1573,7 +1573,7 @@ static int I3Cx_SlaveTransmit(I3C_RESOURCES *i3c, const uint8_t *data, uint16_t 
 /**
   \fn           int I3Cx_SlaveReceive(I3C_RESOURCES *i3c,
                                       uint8_t       *data,
-                                      uint32_t       len)
+                                      uint16_t       len)
   \brief        Read data from the master
   \param[in]    i3c      : Pointer to i3c resources structure
   \param[in]    data     : Pointer to buffer for data
@@ -1581,7 +1581,7 @@ static int I3Cx_SlaveTransmit(I3C_RESOURCES *i3c, const uint8_t *data, uint16_t 
   \param[in]    len      : Number of bytes needs to be receive
   \return       \ref execution_status
 */
-static int I3Cx_SlaveReceive(I3C_RESOURCES *i3c, uint8_t *data, uint32_t len)
+static int I3Cx_SlaveReceive(I3C_RESOURCES *i3c, uint8_t *data, uint16_t len)
 {
 #if I3C_DMA_ENABLE
     int32_t ret;

--- a/Alif_CMSIS/Source/Driver_I3C_Private.h
+++ b/Alif_CMSIS/Source/Driver_I3C_Private.h
@@ -23,6 +23,9 @@ extern "C" {
 #include "i3c.h"
 #include "sys_ctrl_i3c.h"
 
+#define I3C_DIR_TRANSMITTER    (0) /* direction transmitter  */
+#define I3C_DIR_RECEIVER       (1) /* direction receiver     */
+
 /* Check if DMA Support is enable? */
 #if (RTE_I3C_DMA_ENABLE || RTE_LPI3C_DMA_ENABLE)
 #define I3C_DMA_ENABLE 1

--- a/drivers/include/i3c.h
+++ b/drivers/include/i3c.h
@@ -20,6 +20,7 @@ extern "C" {
 
 /* common helpers */
 #define BIT(nr)                            (1UL << (nr))
+#define TOTAL_BITS(x)                      (sizeof(x) * 8)
 
 #define GENMASK(h, l)                      (((~(0U)) - ((1U) << (l)) + 1) & (~(0U) >> (32 - 1 - (h))))
 
@@ -192,6 +193,7 @@ extern "C" {
 #define I3C_DATA_BUFFER_THLD_CTRL_TX_EMPTY_BUF_THLD_Pos 0U
 #define I3C_DATA_BUFFER_THLD_CTRL_TX_EMPTY_BUF_THLD_Msk                                            \
     GENMASK(2, I3C_DATA_BUFFER_THLD_CTRL_TX_EMPTY_BUF_THLD_Pos)
+#define I3C_DATA_BUFFER_THLD_CTRL_MAX_THLD        0x5
 
 #define I3C_IBI_QUEUE_CTRL_NOTIFY_SIR_REJECTED    (1U << 3U)
 #define I3C_IBI_QUEUE_CTRL_NOTIFY_MR_REJECTED     (1U << 1U)
@@ -885,6 +887,45 @@ static inline uint8_t i3c_get_rx_buf_thld(I3C_Type *i3c)
     }
 
     return rx_thld_val;
+}
+
+/**
+  \fn          uint8_t i3c_get_buflen_to_threshold(uint16_t buflen)
+  \brief       Get buffer threshold for buffer length (in bytes)
+  \            Each entry is of 4 bytes.
+  \param[in]   bytes  Length of data in bytes
+  \return      Buffer thresold value
+*/
+static inline uint8_t i3c_get_buflen_to_threshold(uint16_t buflen)
+{
+    uint8_t threshold = 0;
+    uint8_t pos = TOTAL_BITS(buflen) - 1;
+
+    /* As per DW I3C Datasheet:
+     * threshold = 1 entry when bytes = 16 (4th bit),
+     * threshold = 2 entries when bytes = 32 (5th bit),
+     * threshold = 3 entries when bytes = 64 (6th bit) .. continues
+     */
+    while (pos > 3) {
+        /* Iterate from last bit till 4th bit to find the MSB */
+        if (buflen & BIT(pos)) {
+            threshold = pos;
+            break;
+        } else {
+            pos--;
+        }
+    }
+
+    if (threshold) {
+        /* The valid threshold is from bit 4*/
+        threshold -= 3;
+
+        if (threshold > I3C_DATA_BUFFER_THLD_CTRL_MAX_THLD) {
+            threshold = I3C_DATA_BUFFER_THLD_CTRL_MAX_THLD;
+        }
+    }
+
+    return threshold;
 }
 
 /**

--- a/drivers/source/i3c.c
+++ b/drivers/source/i3c.c
@@ -84,27 +84,16 @@ static void i3c_read_rx_fifo(I3C_Type *i3c, uint8_t *bytes, uint32_t nbytes)
 */
 static void i3c_set_tx_buf_thld(I3C_Type *i3c, const uint16_t len)
 {
-    uint16_t loc_len = (len / 4);
-    uint8_t  rem     = (len % 4);
+    uint8_t thld;
+
     uint32_t temp =
         (i3c->I3C_DATA_BUFFER_THLD_CTRL & (~I3C_DATA_BUFFER_THLD_CTRL_TX_EMPTY_BUF_THLD_Msk));
 
-    /* In DMA mode the threshold is forced to 0 so the peripheral
-     * request line asserts on any FIFO occupancy. A length-scaled
-     * threshold would starve short-after-long TX sequences (the
-     * FIFO would never reach the previous transfer's threshold)
-     */
-    if (!i3c_is_dma_enable(i3c) && len > 4) {
-        if (rem) {
-            /* Set 1 extra location */
-            temp |= (((loc_len + 1) << I3C_DATA_BUFFER_THLD_CTRL_TX_EMPTY_BUF_THLD_Pos) &
-                     I3C_DATA_BUFFER_THLD_CTRL_TX_EMPTY_BUF_THLD_Msk);
-        } else {
-            /* Set actual number of locations */
-            temp |= ((loc_len << I3C_DATA_BUFFER_THLD_CTRL_TX_EMPTY_BUF_THLD_Pos) &
-                     I3C_DATA_BUFFER_THLD_CTRL_TX_EMPTY_BUF_THLD_Msk);
-        }
-    }
+    thld = i3c_get_buflen_to_threshold(len);
+
+    /* Set the calculated threshold */
+    temp |= ((thld << I3C_DATA_BUFFER_THLD_CTRL_TX_EMPTY_BUF_THLD_Pos) &
+                      I3C_DATA_BUFFER_THLD_CTRL_TX_EMPTY_BUF_THLD_Msk);
 
     i3c->I3C_DATA_BUFFER_THLD_CTRL = temp;
 }
@@ -119,24 +108,15 @@ static void i3c_set_tx_buf_thld(I3C_Type *i3c, const uint16_t len)
 */
 static void i3c_set_rx_buf_thld(I3C_Type *i3c, const uint16_t len)
 {
-    uint16_t loc_len = (len / 4);
-    uint8_t  rem     = (len % 4);
+    uint8_t thld;
+
     uint32_t temp = (i3c->I3C_DATA_BUFFER_THLD_CTRL & (~I3C_DATA_BUFFER_THLD_CTRL_RX_BUF_THLD_Msk));
 
-    /* In DMA mode the threshold is forced to 0 so partial data on
-     * early termination reaches the buffer — a length-scaled
-     * threshold would trap short reads in the FIFO because the level
-     * never crosses the previous transfer's threshold
-     */
-    if (!i3c_is_dma_enable(i3c) && len > 4) {
-        if (rem) {
-            temp |= (((loc_len + 1) << I3C_DATA_BUFFER_THLD_CTRL_RX_BUF_THLD_Pos) &
-                     I3C_DATA_BUFFER_THLD_CTRL_RX_BUF_THLD_Msk);
-        } else {
-            temp |= ((loc_len << I3C_DATA_BUFFER_THLD_CTRL_RX_BUF_THLD_Pos) &
-                     I3C_DATA_BUFFER_THLD_CTRL_RX_BUF_THLD_Msk);
-        }
-    }
+    thld  = i3c_get_buflen_to_threshold(len);
+
+    /* Set the calculated threshold */
+    temp |= ((thld << I3C_DATA_BUFFER_THLD_CTRL_RX_BUF_THLD_Pos) &
+                      I3C_DATA_BUFFER_THLD_CTRL_RX_BUF_THLD_Msk);
 
     i3c->I3C_DATA_BUFFER_THLD_CTRL = temp;
 }

--- a/drivers/source/i3c.c
+++ b/drivers/source/i3c.c
@@ -1605,7 +1605,10 @@ void i3c_master_irq_handler(I3C_Type *i3c, i3c_xfer_t *xfer)
         case I3C_MST_RX_TID:
         case I3C_CCC_GET_TID:
             if (xfer->rx_len) {
-                i3c_receive(i3c, xfer, rx_len);
+                resp = i3c_get_avail_rx_buf_len(i3c);
+                if (resp) {
+                    i3c_receive(i3c, xfer, resp);
+                }
 
                 if (tid == I3C_MST_RX_TID && rx_len < xfer->rx_len) {
                     /* Slave asserted T=0 before delivering all requested bytes.
@@ -1800,7 +1803,10 @@ void i3c_slave_irq_handler(I3C_Type *i3c, i3c_xfer_t *xfer)
                      */
                     xfer->rx_cur_cnt = rx_len;
                 } else {
-                    i3c_receive(i3c, xfer, rx_len);
+                    resp = i3c_get_avail_rx_buf_len(i3c);
+                    if (resp) {
+                        i3c_receive(i3c, xfer, resp);
+                    }
 
                     if (xfer->rx_cur_cnt >= xfer->rx_len) {
                         i3c_disable_intr(i3c, I3C_INTR_STATUS_RX_THLD_STS);


### PR DESCRIPTION
-- Add an api "GetDataCount" to fetch number of data bytes being transferred in an ongoing transaction.
-- Add a check for rx data availability before reading it when the HW provides status repsonse for current transfer.
-- Add an api to convert xfer buffer length (in bytes) to register threshold values.