### PR TITLE
I2C: implement custom microcode for DMA transfers

### DIFF
--- a/Alif_CMSIS/Source/Driver_I2C.c
+++ b/Alif_CMSIS/Source/Driver_I2C.c
@@ -11,10 +11,14 @@
 /* Includes */
 #include <stddef.h>
 #include <stdint.h>
-#include "stdio.h"
 
 /* system includes */
 #include "Driver_I2C_Private.h"
+
+#if I2C_DMA_ENABLE
+#include "sys_utils.h"
+#include "dma_config.h"
+#endif
 
 /* Driver version */
 #define ARM_I2C_DRV_VERSION ARM_DRIVER_VERSION_MAJOR_MINOR(1, 11)
@@ -249,6 +253,405 @@ __STATIC_INLINE int32_t I2C_DMA_Stop(DMA_PERIPHERAL_CONFIG *dma_periph)
         return ARM_DRIVER_ERROR;
     }
 
+    return ARM_DRIVER_OK;
+}
+
+/* 16-bit DATA_CMD words used as fixed sources for Master-RX command issuance */
+static const uint16_t I2C_DMA_READ_REQ_WORD      = I2C_IC_DATA_CMD_READ_REQ;
+static const uint16_t I2C_DMA_READ_REQ_STOP_WORD = I2C_IC_DATA_CMD_READ_REQ | I2C_IC_DATA_CMD_STOP;
+
+/**
+ * @brief   User-provided microcode for a DMA channel
+ * @param   dma_periph : Pointer to DMA resources
+ * @param   dma_mcode  : Global address of the microcode buffer
+ * @retval  execution_status
+ */
+__STATIC_INLINE int32_t I2C_DMA_Usermcode(DMA_PERIPHERAL_CONFIG *dma_periph, uint32_t dma_mcode)
+{
+    int32_t         status;
+    ARM_DRIVER_DMA *dma_drv = dma_periph->dma_drv;
+
+    status = dma_drv->Control(&dma_periph->dma_handle, ARM_DMA_USER_PROVIDED_MCODE, dma_mcode);
+    if (status) {
+        return ARM_DRIVER_ERROR;
+    }
+    return ARM_DRIVER_OK;
+}
+
+/**
+ * @brief   Build microcode that streams 16-bit DATA_CMD words from the scratch
+ *          buffer to I2Cx->I2C_DATA_CMD. Used for Master TX, Slave TX, and the
+ *          W/R prefix bytes of Master RX combined transfers.
+ * @param   I2C        : Pointer to I2C resources
+ * @param   dma_periph : TX-channel DMA peripheral config
+ * @param   chunk_cnt  : Number of 16-bit scratch entries to push (1..DMA_MAX_LP_CNT)
+ * @retval  true on success
+ */
+static bool I2C_DMA_GenOpcode_TxShadow(I2C_RESOURCES *I2C, DMA_PERIPHERAL_CONFIG *dma_periph,
+                                       uint32_t chunk_cnt)
+{
+    dma_opcode_buf op_buf;
+    dma_ccr_t      ccr;
+    dma_loop_t     lp_args;
+    uint16_t       lp_start;
+    uint8_t        periph_num = dma_periph->dma_periph_req;
+    uint8_t        dma_handle = (uint8_t) dma_periph->dma_handle;
+
+    if ((chunk_cnt == 0) || (chunk_cnt > DMA_MAX_LP_CNT)) {
+        return false;
+    }
+
+    op_buf.buf      = I2C->dma_mcode;
+    op_buf.buf_size = I2C_DMA_MCODE_SIZE;
+    op_buf.off      = 0;
+
+    ccr.value                  = 0;
+    ccr.value_b.src_inc        = DMA_BURST_INCREMENTING;
+    ccr.value_b.src_burst_size = BS_BYTE_2;
+    ccr.value_b.src_cache_ctrl = DMA_SRC_CACHE_CTRL;
+    ccr.value_b.dst_inc        = DMA_BURST_FIXED;
+    ccr.value_b.dst_burst_size = BS_BYTE_2;
+
+    if (!dma_construct_move(ccr.value, DMA_REG_CCR, &op_buf)) {
+        return false;
+    }
+    if (!dma_construct_move(LocalToGlobal(I2C->dma_tx_scratch), DMA_REG_SAR, &op_buf)) {
+        return false;
+    }
+    if (!dma_construct_move(LocalToGlobal(i2c_get_data_addr(I2C->regs)), DMA_REG_DAR, &op_buf)) {
+        return false;
+    }
+
+    if (!dma_construct_loop(DMA_LC_0, (uint8_t) chunk_cnt, &op_buf)) {
+        return false;
+    }
+    lp_start = (uint16_t) op_buf.off;
+
+    if (!dma_construct_flushperiph(periph_num, &op_buf)) {
+        return false;
+    }
+    if (!dma_construct_wfp(DMA_XFER_SINGLE, periph_num, &op_buf)) {
+        return false;
+    }
+    if (!dma_construct_load(DMA_XFER_FORCE, &op_buf)) {
+        return false;
+    }
+    if (!dma_construct_storeperiph(DMA_XFER_SINGLE, periph_num, &op_buf)) {
+        return false;
+    }
+
+    if ((op_buf.off - lp_start) > DMA_MAX_BACKWARD_JUMP) {
+        return false;
+    }
+    lp_args.jump      = (uint8_t) (op_buf.off - lp_start);
+    lp_args.lc        = DMA_LC_0;
+    lp_args.nf        = 1;
+    lp_args.xfer_type = DMA_XFER_FORCE;
+    if (!dma_construct_loopend(&lp_args, &op_buf)) {
+        return false;
+    }
+
+    if (!dma_construct_wmb(&op_buf)) {
+        return false;
+    }
+    if (!dma_construct_send_event(dma_handle, &op_buf)) {
+        return false;
+    }
+    if (!dma_construct_end(&op_buf)) {
+        return false;
+    }
+
+    RTSS_CleanDCache_by_Addr(op_buf.buf, op_buf.buf_size);
+    return true;
+}
+
+/**
+ * @brief   Build microcode that issues READ_REQ commands followed by an
+ *          optional READ_REQ|STOP terminator. Used for Master RX (data phase).
+ *          The optional W/R prefix (from scratch buffer) is emitted first when
+ *          prefix_cnt > 0.
+ * @param   I2C        : Pointer to I2C resources
+ * @param   dma_periph : TX-channel DMA peripheral config
+ * @param   prefix_cnt : Number of W/R prefix bytes from dma_tx_scratch (0 if none)
+ * @param   rx_total   : Number of READ_REQ words to push (1..DMA_MAX_LP_CNT, total reads)
+ * @param   emit_stop  : True to OR STOP into the last READ_REQ word
+ * @retval  true on success
+ */
+static bool I2C_DMA_GenOpcode_MasterRxCmd(I2C_RESOURCES *I2C, DMA_PERIPHERAL_CONFIG *dma_periph,
+                                          uint32_t prefix_cnt, uint32_t rx_total, bool emit_stop)
+{
+    dma_opcode_buf op_buf;
+    dma_ccr_t      ccr;
+    dma_loop_t     lp_args;
+    uint16_t       lp_start;
+    uint8_t        periph_num = dma_periph->dma_periph_req;
+    uint8_t        dma_handle = (uint8_t) dma_periph->dma_handle;
+
+    if ((rx_total == 0) || (rx_total > DMA_MAX_LP_CNT) || (prefix_cnt > DMA_MAX_LP_CNT)) {
+        return false;
+    }
+
+    op_buf.buf      = I2C->dma_mcode;
+    op_buf.buf_size = I2C_DMA_MCODE_SIZE;
+    op_buf.off      = 0;
+
+    if (!dma_construct_move(LocalToGlobal(i2c_get_data_addr(I2C->regs)), DMA_REG_DAR, &op_buf)) {
+        return false;
+    }
+
+    /* W/R prefix phase: source = scratch (incrementing) */
+    if (prefix_cnt > 0) {
+        ccr.value                  = 0;
+        ccr.value_b.src_inc        = DMA_BURST_INCREMENTING;
+        ccr.value_b.src_burst_size = BS_BYTE_2;
+        ccr.value_b.src_cache_ctrl = DMA_SRC_CACHE_CTRL;
+        ccr.value_b.dst_inc        = DMA_BURST_FIXED;
+        ccr.value_b.dst_burst_size = BS_BYTE_2;
+        if (!dma_construct_move(ccr.value, DMA_REG_CCR, &op_buf)) {
+            return false;
+        }
+        if (!dma_construct_move(LocalToGlobal(I2C->dma_tx_scratch), DMA_REG_SAR, &op_buf)) {
+            return false;
+        }
+
+        if (!dma_construct_loop(DMA_LC_0, (uint8_t) prefix_cnt, &op_buf)) {
+            return false;
+        }
+        lp_start = (uint16_t) op_buf.off;
+        if (!dma_construct_flushperiph(periph_num, &op_buf)) {
+            return false;
+        }
+        if (!dma_construct_wfp(DMA_XFER_SINGLE, periph_num, &op_buf)) {
+            return false;
+        }
+        if (!dma_construct_load(DMA_XFER_FORCE, &op_buf)) {
+            return false;
+        }
+        if (!dma_construct_storeperiph(DMA_XFER_SINGLE, periph_num, &op_buf)) {
+            return false;
+        }
+        if ((op_buf.off - lp_start) > DMA_MAX_BACKWARD_JUMP) {
+            return false;
+        }
+        lp_args.jump      = (uint8_t) (op_buf.off - lp_start);
+        lp_args.lc        = DMA_LC_0;
+        lp_args.nf        = 1;
+        lp_args.xfer_type = DMA_XFER_FORCE;
+        if (!dma_construct_loopend(&lp_args, &op_buf)) {
+            return false;
+        }
+    }
+
+    /* READ_REQ phase: source = fixed (READ_REQ_WORD), N-1 iterations */
+    ccr.value                  = 0;
+    ccr.value_b.src_inc        = DMA_BURST_FIXED;
+    ccr.value_b.src_burst_size = BS_BYTE_2;
+    ccr.value_b.src_cache_ctrl = DMA_SRC_CACHE_CTRL;
+    ccr.value_b.dst_inc        = DMA_BURST_FIXED;
+    ccr.value_b.dst_burst_size = BS_BYTE_2;
+    if (!dma_construct_move(ccr.value, DMA_REG_CCR, &op_buf)) {
+        return false;
+    }
+    if (!dma_construct_move(LocalToGlobal(&I2C_DMA_READ_REQ_WORD), DMA_REG_SAR, &op_buf)) {
+        return false;
+    }
+
+    if (rx_total > 1) {
+        if (!dma_construct_loop(DMA_LC_0, (uint8_t) (rx_total - 1), &op_buf)) {
+            return false;
+        }
+        lp_start = (uint16_t) op_buf.off;
+        if (!dma_construct_flushperiph(periph_num, &op_buf)) {
+            return false;
+        }
+        if (!dma_construct_wfp(DMA_XFER_SINGLE, periph_num, &op_buf)) {
+            return false;
+        }
+        if (!dma_construct_load(DMA_XFER_FORCE, &op_buf)) {
+            return false;
+        }
+        if (!dma_construct_storeperiph(DMA_XFER_SINGLE, periph_num, &op_buf)) {
+            return false;
+        }
+        if ((op_buf.off - lp_start) > DMA_MAX_BACKWARD_JUMP) {
+            return false;
+        }
+        lp_args.jump      = (uint8_t) (op_buf.off - lp_start);
+        lp_args.lc        = DMA_LC_0;
+        lp_args.nf        = 1;
+        lp_args.xfer_type = DMA_XFER_FORCE;
+        if (!dma_construct_loopend(&lp_args, &op_buf)) {
+            return false;
+        }
+    }
+
+    /* Final READ_REQ word: optionally with STOP */
+    if (emit_stop) {
+        if (!dma_construct_move(LocalToGlobal(&I2C_DMA_READ_REQ_STOP_WORD), DMA_REG_SAR, &op_buf)) {
+            return false;
+        }
+    }
+    if (!dma_construct_flushperiph(periph_num, &op_buf)) {
+        return false;
+    }
+    if (!dma_construct_wfp(DMA_XFER_SINGLE, periph_num, &op_buf)) {
+        return false;
+    }
+    if (!dma_construct_load(DMA_XFER_FORCE, &op_buf)) {
+        return false;
+    }
+    if (!dma_construct_storeperiph(DMA_XFER_SINGLE, periph_num, &op_buf)) {
+        return false;
+    }
+
+    if (!dma_construct_wmb(&op_buf)) {
+        return false;
+    }
+    if (!dma_construct_send_event(dma_handle, &op_buf)) {
+        return false;
+    }
+    if (!dma_construct_end(&op_buf)) {
+        return false;
+    }
+
+    RTSS_CleanDCache_by_Addr(op_buf.buf, op_buf.buf_size);
+    return true;
+}
+
+/**
+ * @brief   Pack a TX chunk (Master TX / Slave TX) from the user buffer into
+ *          the 16-bit scratch, applying WRITE_REQ flags and an optional STOP
+ *          on the final entry of the final chunk.
+ * @param   I2C       : Pointer to I2C resources
+ * @param   add_stop  : True if STOP is permitted on the terminating byte
+ *                      (i.e. master mode and !xfer_pending; never for slave)
+ * @retval  Number of scratch entries written (== chunk_count, 0 on error)
+ */
+static uint32_t i2c_dma_tx_load_chunk(I2C_RESOURCES *I2C, bool add_stop)
+{
+    uint32_t remaining = I2C->dma_xfer_remaining;
+    uint32_t chunk;
+    uint32_t i;
+    uint32_t chunk_limit;
+
+    if ((remaining == 0) || (I2C->dma_xfer_src == NULL) || (I2C->dma_tx_scratch == NULL)) {
+        return 0;
+    }
+
+    chunk_limit = (I2C->dma_tx_scratch_sz > DMA_MAX_LP_CNT)
+                      ? DMA_MAX_LP_CNT
+                      : I2C->dma_tx_scratch_sz;
+    chunk       = (remaining > chunk_limit) ? chunk_limit : remaining;
+
+    for (i = 0; i < chunk; i++) {
+        I2C->dma_tx_scratch[i] =
+            (uint16_t) I2C->dma_xfer_src[i] | I2C_IC_DATA_CMD_WRITE_REQ;
+    }
+
+    /* STOP applies only to the final byte of the final chunk for a master
+     * transfer that is not pending. Slave transfers must never set STOP.
+     */
+    if (add_stop && (chunk == remaining) && (!I2C->dma_xfer_pending)) {
+        I2C->dma_tx_scratch[chunk - 1] |= I2C_IC_DATA_CMD_STOP;
+    }
+
+    I2C->dma_xfer_src        += chunk;
+    I2C->dma_xfer_remaining  -= chunk;
+
+    RTSS_CleanDCache_by_Addr(I2C->dma_tx_scratch,
+        (int32_t) (I2C->dma_tx_scratch_sz * sizeof(uint16_t)));
+    return chunk;
+}
+
+/**
+ * @brief   Submit the next TX chunk: pack scratch, build microcode,
+ *          and start the TX DMA channel. Used by both the initial transfer
+ *          setup and the in-callback re-arm path for Master TX / Slave TX.
+ * @param   I2C      : Pointer to I2C resources
+ * @param   add_stop : True for master TX (STOP allowed on final byte),
+ *                     false for slave TX (slave never emits STOP).
+ * @retval  ARM_DRIVER_OK on success, error code otherwise.
+ */
+static int32_t i2c_dma_tx_submit_chunk(I2C_RESOURCES *I2C, bool add_stop)
+{
+    ARM_DMA_PARAMS p;
+    uint32_t       chunk;
+
+    chunk = i2c_dma_tx_load_chunk(I2C, add_stop);
+    if (chunk == 0U) {
+        return ARM_DRIVER_ERROR;
+    }
+
+    if (!I2C_DMA_GenOpcode_TxShadow(I2C, &I2C->dma_cfg->dma_tx, chunk)) {
+        return ARM_DRIVER_ERROR;
+    }
+    if (I2C_DMA_Usermcode(&I2C->dma_cfg->dma_tx, LocalToGlobal(I2C->dma_mcode))
+        != ARM_DRIVER_OK) {
+        return ARM_DRIVER_ERROR;
+    }
+
+    p.peri_reqno   = (int8_t) I2C->dma_cfg->dma_tx.dma_periph_req;
+    p.dir          = ARM_DMA_MEM_TO_DEV;
+    p.cb_event     = I2C->dma_cb;
+    p.src_addr     = (const void *) I2C->dma_tx_scratch;
+    p.dst_addr     = i2c_get_data_addr(I2C->regs);
+    p.num_bytes    = chunk * sizeof(uint16_t);
+    p.irq_priority = I2C->dma_irq_priority;
+    p.burst_size   = BS_BYTE_2;
+    p.burst_len    = 1U;
+
+    return I2C_DMA_Start(&I2C->dma_cfg->dma_tx, &p);
+}
+
+/**
+ * @brief   Submit the next Master-RX READ_REQ command chunk on the TX
+ *          channel. The RX-side data drain runs once for the full transfer
+ *          via the stock DMA path; only the command-issuance microcode
+ *          needs re-arming per chunk.
+ * @param   I2C        : Pointer to I2C resources
+ * @param   prefix_cnt : W/R prefix entries to emit before READ_REQs
+ *                       (non-zero only on the first chunk of a W/R combined
+ *                       transfer; 0 for plain reads and all re-arm chunks).
+ * @retval  ARM_DRIVER_OK on success, error code otherwise.
+ */
+static int32_t i2c_dma_rx_cmd_submit_chunk(I2C_RESOURCES *I2C, uint32_t prefix_cnt)
+{
+    ARM_DMA_PARAMS p;
+    uint32_t       remaining = I2C->dma_xfer_remaining;
+    uint32_t       chunk;
+    bool           emit_stop;
+
+    if (remaining == 0U) {
+        return ARM_DRIVER_ERROR;
+    }
+
+    chunk     = (remaining > DMA_MAX_LP_CNT) ? DMA_MAX_LP_CNT : remaining;
+    emit_stop = (chunk == remaining) && (!I2C->dma_xfer_pending);
+
+    if (!I2C_DMA_GenOpcode_MasterRxCmd(I2C, &I2C->dma_cfg->dma_tx, prefix_cnt, chunk,
+                                       emit_stop)) {
+        return ARM_DRIVER_ERROR;
+    }
+    if (I2C_DMA_Usermcode(&I2C->dma_cfg->dma_tx, LocalToGlobal(I2C->dma_mcode))
+        != ARM_DRIVER_OK) {
+        return ARM_DRIVER_ERROR;
+    }
+
+    p.peri_reqno   = (int8_t) I2C->dma_cfg->dma_tx.dma_periph_req;
+    p.dir          = ARM_DMA_MEM_TO_DEV;
+    p.cb_event     = I2C->dma_cb;
+    p.src_addr     = (const void *) I2C->dma_tx_scratch;
+    p.dst_addr     = i2c_get_data_addr(I2C->regs);
+    p.num_bytes    = (prefix_cnt + chunk) * sizeof(uint16_t);
+    p.irq_priority = I2C->dma_irq_priority;
+    p.burst_size   = BS_BYTE_2;
+    p.burst_len    = 1U;
+
+    if (I2C_DMA_Start(&I2C->dma_cfg->dma_tx, &p) != ARM_DRIVER_OK) {
+        return ARM_DRIVER_ERROR;
+    }
+
+    I2C->dma_xfer_remaining -= chunk;
     return ARM_DRIVER_OK;
 }
 #endif /* I2C_DMA_ENABLE */
@@ -512,10 +915,6 @@ static int32_t ARM_I2C_PowerControl(ARM_POWER_STATE state, I2C_RESOURCES *I2C)
 static int32_t ARM_I2C_MasterTransmit(I2C_RESOURCES *I2C, uint32_t addr, const uint8_t *data,
                                       uint32_t num, bool xfer_pending)
 {
-#if I2C_DMA_ENABLE
-    ARM_DMA_PARAMS dma_params;
-#endif
-
     /* check i2c driver is initialized or not */
     if (I2C->state.initialized == 0) {
         return ARM_DRIVER_ERROR;
@@ -574,39 +973,30 @@ static int32_t ARM_I2C_MasterTransmit(I2C_RESOURCES *I2C, uint32_t addr, const u
 
 #if I2C_DMA_ENABLE
     if (I2C->dma_enable) {
-        /* Nullify Tx buf pointer, total num bytes and pending
-         * fields of I2C transfer structure */
-        I2C->transfer.tx_buf       = (uint8_t *) NULL;
+        /* Clear transfer state */
+        I2C->transfer.tx_buf       = NULL;
+        I2C->transfer.rx_buf       = NULL;
+        I2C->transfer.tx_curr_cnt  = 0U;
+        I2C->transfer.rx_curr_cnt  = 0U;
         I2C->transfer.tx_total_num = 0U;
+        I2C->transfer.rx_total_num = 0U;
+        I2C->transfer.wr_mode      = false;
 
-        /* Start the DMA engine for sending the data to I2C */
-        dma_params.peri_reqno      = (int8_t) I2C->dma_cfg->dma_tx.dma_periph_req;
-        dma_params.dir             = ARM_DMA_MEM_TO_DEV;
-        dma_params.cb_event        = I2C->dma_cb;
-        dma_params.src_addr        = (const void *) data;
-        dma_params.dst_addr        = i2c_get_data_addr(I2C->regs);
-        dma_params.num_bytes       = (num * 2U);
-        dma_params.irq_priority    = I2C->dma_irq_priority;
+        /* Pass the user buffer in chunks */
+        I2C->dma_xfer_src       = data;
+        I2C->dma_xfer_remaining = num;
+        I2C->dma_xfer_total     = num;
+        I2C->dma_xfer_pending   = xfer_pending;
 
-        /* i2c TX/RX FIFO is 2-byte aligned */
-        dma_params.burst_size      = BS_BYTE_2;
-
-        /* Max DMA burst length can be 16*/
-        if ((32U - I2C->tx_fifo_threshold) > 16U) {
-            dma_params.burst_len = 16U;
-        } else {
-            dma_params.burst_len = (32U - I2C->tx_fifo_threshold);
+        if (i2c_dma_tx_submit_chunk(I2C, true) != ARM_DRIVER_OK) {
+            I2C->status.busy        = 0U;
+            I2C->transfer.curr_stat = I2C_XFER_NONE;
+            return ARM_DRIVER_ERROR;
         }
 
         /* Prepare the I2C controller for DMA transmission */
         i2c_enable_tx_dma(I2C->regs);
-
-        i2c_set_dma_tx_level(I2C->regs, dma_params.burst_len);
-
-        /* Start DMA transfer */
-        if (I2C_DMA_Start(&I2C->dma_cfg->dma_tx, &dma_params) != ARM_DRIVER_OK) {
-            return ARM_DRIVER_ERROR;
-        }
+        i2c_set_dma_tx_level(I2C->regs, 0U);
 
         i2c_enable_dma_master_tx(I2C->regs);
 
@@ -643,10 +1033,6 @@ static int32_t ARM_I2C_MasterTransmit(I2C_RESOURCES *I2C, uint32_t addr, const u
 static int32_t ARM_I2C_MasterReceive(I2C_RESOURCES *I2C, uint32_t addr, uint8_t *data, uint32_t num,
                                      bool xfer_pending)
 {
-#if I2C_DMA_ENABLE
-    ARM_DMA_PARAMS dma_params;
-#endif
-
     /* check i2c driver is initialized or not */
     if (I2C->state.initialized == 0) {
         return ARM_DRIVER_ERROR;
@@ -704,52 +1090,107 @@ static int32_t ARM_I2C_MasterReceive(I2C_RESOURCES *I2C, uint32_t addr, uint8_t 
     /* Clear all interrupts */
     i2c_clear_all_interrupt(I2C->regs);
 
+    I2C_SetTargetAddress(I2C, addr);
+
+#if I2C_DMA_ENABLE
+    if (I2C->dma_enable) {
+        ARM_DMA_PARAMS dma_rx_params;
+        uint32_t       prefix_cnt = 0U;
+
+        /* Clear transfer state */
+        I2C->transfer.tx_buf       = NULL;
+        I2C->transfer.rx_buf       = NULL;
+        I2C->transfer.tx_curr_cnt  = 0U;
+        I2C->transfer.rx_curr_cnt  = 0U;
+        I2C->transfer.tx_total_num = 0U;
+        I2C->transfer.rx_total_num = 0U;
+        I2C->transfer.wr_mode      = false;
+
+        if (I2C->wr_mode_info & I2C_WRITE_READ_MODE_EN) {
+            prefix_cnt = I2C_WRITE_READ_TAR_REG_ADDR_SIZE(I2C->wr_mode_info);
+            if (prefix_cnt > I2C->dma_tx_scratch_sz) {
+                I2C->status.busy        = 0U;
+                I2C->transfer.curr_stat = I2C_XFER_NONE;
+                return ARM_DRIVER_ERROR_PARAMETER;
+            }
+
+            I2C->transfer.tx_buf       = (uint8_t *) data;
+            I2C->transfer.tx_total_num = prefix_cnt;
+            I2C->transfer.tx_curr_cnt  = 0U;
+            I2C->transfer.wr_mode      = true;
+
+            /* Pack the W/R-prefix bytes into the scratch without STOP
+             * (RESTART before the read phase is handled by the I2C HW).
+             */
+            I2C->dma_xfer_src       = data;
+            I2C->dma_xfer_remaining = prefix_cnt;
+            I2C->dma_xfer_pending   = true; /* prevent STOP on prefix */
+            (void) i2c_dma_tx_load_chunk(I2C, false);
+        }
+
+        /* Set up READ_REQ command-issuance. dma_xfer_remaining now
+         * tracks how many READ_REQ words are left across chunks; the
+         * DMA callback re-arms the TX channel for transfers > DMA_MAX_LP_CNT.
+         */
+        I2C->dma_xfer_remaining = num;
+        I2C->dma_xfer_total     = num;
+        I2C->dma_xfer_pending   = xfer_pending;
+
+        /* Build + submit the first TX-channel chunk (optional W/R prefix +
+         * up to DMA_MAX_LP_CNT READ_REQs, with STOP only on the very last
+         * chunk and only when not pending).
+         *
+         * Order matters: start the RX channel (DEV->MEM) FIRST so it
+         * waits for data, THEN kick off the TX channel via
+         * submit_chunk.
+         */
+
+        dma_rx_params.peri_reqno   = (int8_t) I2C->dma_cfg->dma_rx.dma_periph_req;
+        dma_rx_params.dir          = ARM_DMA_DEV_TO_MEM;
+        dma_rx_params.cb_event     = I2C->dma_cb;
+        dma_rx_params.src_addr     = i2c_get_data_addr(I2C->regs);
+        dma_rx_params.dst_addr     = (void *) data;
+        dma_rx_params.num_bytes    = num;
+        dma_rx_params.irq_priority = I2C->dma_irq_priority;
+        dma_rx_params.burst_size   = BS_BYTE_1;
+        dma_rx_params.burst_len    = 1U;
+
+        i2c_enable_rx_dma(I2C->regs);
+        i2c_set_dma_rx_level(I2C->regs, 0U);
+
+        if (I2C_DMA_Start(&I2C->dma_cfg->dma_rx, &dma_rx_params) != ARM_DRIVER_OK) {
+            i2c_disable_rx_dma(I2C->regs);
+            I2C->status.busy        = 0U;
+            I2C->transfer.curr_stat = I2C_XFER_NONE;
+            return ARM_DRIVER_ERROR;
+        }
+
+        /* TX-channel kickoff via submit_chunk (READ_REQ microcode) */
+        if (i2c_dma_rx_cmd_submit_chunk(I2C, prefix_cnt) != ARM_DRIVER_OK) {
+            (void) I2C_DMA_Stop(&I2C->dma_cfg->dma_rx);
+            i2c_disable_rx_dma(I2C->regs);
+            I2C->status.busy        = 0U;
+            I2C->transfer.curr_stat = I2C_XFER_NONE;
+            return ARM_DRIVER_ERROR;
+        }
+
+        i2c_enable_tx_dma(I2C->regs);
+        i2c_set_dma_tx_level(I2C->regs, 0U);
+
+        i2c_enable_dma_master_rx(I2C->regs);
+
+        return ARM_DRIVER_OK;
+    }
+#endif
     if (I2C->wr_mode_info & I2C_WRITE_READ_MODE_EN) {
         /* fill the i2c transfer structure required for Write-Read xfer */
         I2C->transfer.tx_buf       = (uint8_t *) data;
         I2C->transfer.tx_total_num = I2C_WRITE_READ_TAR_REG_ADDR_SIZE(I2C->wr_mode_info);
         I2C->transfer.tx_curr_cnt  = 0U;
         I2C->transfer.wr_mode      = true;
-        I2C_SetTargetAddress(I2C, addr);
-        /* enable master rx interrupt */
-        i2c_master_enable_rx_interrupt(I2C->regs);
-    } else {
-        I2C_SetTargetAddress(I2C, addr);
-
-#if I2C_DMA_ENABLE
-        /* Check if DMA is enabled for this */
-        if (I2C->dma_enable) {
-            /* Start the DMA engine for sending the data to I2C */
-            dma_params.peri_reqno   = (int8_t) I2C->dma_cfg->dma_rx.dma_periph_req;
-            dma_params.dir          = ARM_DMA_DEV_TO_MEM;
-            dma_params.cb_event     = I2C->dma_cb;
-            dma_params.src_addr     = i2c_get_data_addr(I2C->regs);
-            dma_params.dst_addr     = (void *) data;
-            dma_params.num_bytes    = (num * 2U);
-            dma_params.irq_priority = I2C->dma_irq_priority;
-
-            /* i2c TX/RX FIFO is 2-byte aligned */
-            dma_params.burst_size   = BS_BYTE_2;
-
-            /* Maximum DMA Rx burst length can be 1*/
-            dma_params.burst_len    = 1U;
-
-            i2c_enable_rx_dma(I2C->regs);
-            i2c_set_dma_rx_level(I2C->regs, (dma_params.burst_len - 1U));
-
-            /* Start DMA transfer */
-            if (I2C_DMA_Start(&I2C->dma_cfg->dma_rx, &dma_params) != ARM_DRIVER_OK) {
-                return ARM_DRIVER_ERROR;
-            }
-
-            i2c_enable_dma_master_rx(I2C->regs);
-        } else
-#endif
-        {
-            /* enable master rx interrupt */
-            i2c_master_enable_rx_interrupt(I2C->regs);
-        }
     }
+    /* enable master rx interrupt */
+    i2c_master_enable_rx_interrupt(I2C->regs);
     return ARM_DRIVER_OK;
 }
 
@@ -769,10 +1210,6 @@ static int32_t ARM_I2C_MasterReceive(I2C_RESOURCES *I2C, uint32_t addr, uint8_t 
  */
 static int32_t ARM_I2C_SlaveTransmit(I2C_RESOURCES *I2C, const uint8_t *data, uint32_t num)
 {
-#if I2C_DMA_ENABLE
-    ARM_DMA_PARAMS dma_params;
-#endif
-
     /* check i2c driver is initialized or not */
     if (I2C->state.initialized == 0) {
         return ARM_DRIVER_ERROR;
@@ -818,40 +1255,30 @@ static int32_t ARM_I2C_SlaveTransmit(I2C_RESOURCES *I2C, const uint8_t *data, ui
 
 #if I2C_DMA_ENABLE
     if (I2C->dma_enable) {
-        /* Nullify Tx buf pointer and total num bytes
-         * of I2C transfer structure */
-        I2C->transfer.tx_buf       = (uint8_t *) NULL;
+        /* Clear transfer state */
+        I2C->transfer.tx_buf       = NULL;
+        I2C->transfer.rx_buf       = NULL;
+        I2C->transfer.tx_curr_cnt  = 0U;
+        I2C->transfer.rx_curr_cnt  = 0U;
         I2C->transfer.tx_total_num = 0U;
+        I2C->transfer.rx_total_num = 0U;
+        I2C->transfer.wr_mode      = false;
 
-        /* Start the DMA engine for sending the data to I2C */
-        dma_params.peri_reqno      = (int8_t) I2C->dma_cfg->dma_tx.dma_periph_req;
-        dma_params.dir             = ARM_DMA_MEM_TO_DEV;
-        dma_params.cb_event        = I2C->dma_cb;
-        dma_params.src_addr        = (const void *) data;
-        dma_params.dst_addr        = i2c_get_data_addr(I2C->regs);
-        dma_params.num_bytes       = (num * 2U);
-        dma_params.irq_priority    = I2C->dma_irq_priority;
+        I2C->dma_xfer_src       = data;
+        I2C->dma_xfer_remaining = num;
+        I2C->dma_xfer_total     = num;
 
-        /* i2c TX/RX FIFO is 2-byte aligned */
-        dma_params.burst_size      = BS_BYTE_2;
+        i2c_set_dma_tx_level(I2C->regs, 0U);
 
-        /* Max DMA burst length can be 16*/
-        if ((32U - I2C->tx_fifo_threshold) > 16U) {
-            dma_params.burst_len = 16U;
-        } else {
-            dma_params.burst_len = (32U - I2C->tx_fifo_threshold);
-        }
-
-        /* Prepare the I2C controller for DMA transmission */
-        i2c_enable_tx_dma(I2C->regs);
-
-        i2c_set_dma_tx_level(I2C->regs, dma_params.burst_len);
-
-        /* Start DMA transfer */
-        if (I2C_DMA_Start(&I2C->dma_cfg->dma_tx, &dma_params) != ARM_DRIVER_OK) {
+        if (i2c_dma_tx_submit_chunk(I2C, false) != ARM_DRIVER_OK) {
+            I2C->status.busy        = 0U;
+            I2C->transfer.curr_stat = I2C_XFER_NONE;
             return ARM_DRIVER_ERROR;
         }
 
+        /* Unmask RD_REQ + TX_ABRT + STOP_DET. The slave-TX ISR enables
+         * TDMAE on RD_REQ.
+         */
         i2c_enable_dma_slave_tx(I2C->regs);
     } else
 #endif
@@ -931,31 +1358,38 @@ static int32_t ARM_I2C_SlaveReceive(I2C_RESOURCES *I2C, uint8_t *data, uint32_t 
 
 #if I2C_DMA_ENABLE
     if (I2C->dma_enable) {
-        /* Nullify Rx buf pointer and total num bytes
-         * of I2C transfer structure */
-        I2C->transfer.rx_buf       = (uint8_t *) NULL;
+        /* Clear transfer state */
+        I2C->transfer.tx_buf       = NULL;
+        I2C->transfer.rx_buf       = NULL;
+        I2C->transfer.tx_curr_cnt  = 0U;
+        I2C->transfer.rx_curr_cnt  = 0U;
+        I2C->transfer.tx_total_num = 0U;
         I2C->transfer.rx_total_num = 0U;
+        I2C->transfer.wr_mode      = false;
 
-        /* Start the DMA engine for sending the data to I2C */
-        dma_params.peri_reqno      = (int8_t) I2C->dma_cfg->dma_rx.dma_periph_req;
-        dma_params.dir             = ARM_DMA_DEV_TO_MEM;
-        dma_params.cb_event        = I2C->dma_cb;
-        dma_params.src_addr        = i2c_get_data_addr(I2C->regs);
-        dma_params.dst_addr        = (void *) data;
-        dma_params.num_bytes       = (num * 2);
-        dma_params.irq_priority    = I2C->dma_irq_priority;
+        I2C->transfer.rx_buf       = (uint8_t *) data;
+        I2C->transfer.rx_total_num = num;
+        I2C->dma_xfer_remaining    = 0U;
+        I2C->dma_xfer_total        = num;
 
-        /* i2c TX/RX FIFO is 2-byte aligned */
-        dma_params.burst_size      = BS_BYTE_2;
-
-        /* Maximum DMA Rx burst length can be 1*/
-        dma_params.burst_len       = 1U;
+        dma_params.peri_reqno   = (int8_t) I2C->dma_cfg->dma_rx.dma_periph_req;
+        dma_params.dir          = ARM_DMA_DEV_TO_MEM;
+        dma_params.cb_event     = I2C->dma_cb;
+        dma_params.src_addr     = i2c_get_data_addr(I2C->regs);
+        dma_params.dst_addr     = (void *) data;
+        dma_params.num_bytes    = num;
+        dma_params.irq_priority = I2C->dma_irq_priority;
+        dma_params.burst_size   = BS_BYTE_1;
+        dma_params.burst_len    = 1U;
 
         i2c_enable_rx_dma(I2C->regs);
-        i2c_set_dma_rx_level(I2C->regs, (dma_params.burst_len - 1U));
+        i2c_set_dma_rx_level(I2C->regs, 0U);
 
-        /* Start DMA transfer */
         if (I2C_DMA_Start(&I2C->dma_cfg->dma_rx, &dma_params) != ARM_DRIVER_OK) {
+            /* RDMAE was set above; clear it (no DMA channel was started). */
+            i2c_disable_rx_dma(I2C->regs);
+            I2C->status.busy        = 0U;
+            I2C->transfer.curr_stat = I2C_XFER_NONE;
             return ARM_DRIVER_ERROR;
         }
 
@@ -976,14 +1410,39 @@ static int32_t ARM_I2C_SlaveReceive(I2C_RESOURCES *I2C, uint8_t *data, uint32_t 
 
 /**
  * @brief   CMSIS-Driver i2c get transfer data count
- * @note    it can be either transmit or receive data count which perform last
- *          (useful only in interrupt mode)
+ * @note    Returns data count
  * @param   I2C   : Pointer to i2c resources structure
  * @retval  transfer data count
  */
 static int32_t ARM_I2C_GetDataCount(const I2C_RESOURCES *I2C)
 {
-    /* return common count for both tx/rx */
+#if I2C_DMA_ENABLE
+    if (I2C->dma_enable && I2C->status.busy) {
+        uint32_t dma_count = 0;
+        ARM_DRIVER_DMA *dma_drv;
+        DMA_Handle_Type *handle;
+
+        if (I2C->status.direction == I2C_DIR_TRANSMITTER) {
+            dma_drv = I2C->dma_cfg->dma_tx.dma_drv;
+            handle  = (DMA_Handle_Type *)&I2C->dma_cfg->dma_tx.dma_handle;
+            (void) dma_drv->GetStatus(handle, &dma_count);
+            /* TX DMA transfers 16-bit DATA_CMD words; convert to byte count.
+             * curr_cnt holds bytes completed in prior chunks; dma_count is
+             * the in-flight progress within the current chunk.
+             */
+            return (int32_t)(I2C->transfer.curr_cnt + dma_count / 2U);
+        } else {
+            dma_drv = I2C->dma_cfg->dma_rx.dma_drv;
+            handle  = (DMA_Handle_Type *)&I2C->dma_cfg->dma_rx.dma_handle;
+            (void) dma_drv->GetStatus(handle, &dma_count);
+            /* RX channel runs once for the full transfer; dma_count is
+             * already the full-transfer byte progress.
+             */
+            return (int32_t) dma_count;
+        }
+    }
+#endif
+
     return (int32_t) I2C->transfer.curr_cnt;
 }
 
@@ -1151,11 +1610,25 @@ void I2C_HandleIRQError(I2C_RESOURCES *I2C_RES)
     ARM_I2C_STATUS      *i2c_stat = &(I2C_RES->status);
 
 #if I2C_DMA_ENABLE
+        /* Stop both DMA channels on error. Master RX uses both TX (cmd issuance)
+         * and RX (data drain); stopping only one based on direction leaves the
+         * other channel stalled. Stopping an inactive channel is harmless.
+         */
         if (I2C_RES->dma_enable) {
-            if (I2C_RES->status.direction == I2C_DIR_TRANSMITTER) {
-                I2C_DMA_Stop(&I2C_RES->dma_cfg->dma_tx);
+            uint32_t dma_count = 0;
+
+            I2C_DMA_Stop(&I2C_RES->dma_cfg->dma_tx);
+            I2C_DMA_Stop(&I2C_RES->dma_cfg->dma_rx);
+
+            /* Capture partial count for GetDataCount */
+            if (i2c_stat->direction == I2C_DIR_TRANSMITTER) {
+                (void) I2C_RES->dma_cfg->dma_tx.dma_drv->GetStatus(
+                           &I2C_RES->dma_cfg->dma_tx.dma_handle, &dma_count);
+                transfer->curr_cnt += dma_count / 2U;
             } else {
-                I2C_DMA_Stop(&I2C_RES->dma_cfg->dma_rx);
+                (void) I2C_RES->dma_cfg->dma_rx.dma_drv->GetStatus(
+                           &I2C_RES->dma_cfg->dma_rx.dma_handle, &dma_count);
+                transfer->curr_cnt = dma_count;
             }
         }
 #endif
@@ -1226,13 +1699,19 @@ void I2C_HandleIRQStatus(I2C_RESOURCES *I2C_RES)
     /* Check the ISR response */
     if (transfer->evt_sts & I2C_XFER_EVENT_DONE) {
 
+#if I2C_DMA_ENABLE
+        /* Successful end-of-transaction: curr_cnt = full transfer size */
+        if (I2C_RES->dma_enable) {
+            transfer->curr_cnt = I2C_RES->dma_xfer_total;
+        }
+#endif
+
         I2C_RES->cb_event(ARM_I2C_EVENT_TRANSFER_DONE);
 
     } else if (transfer->evt_sts & I2C_XFER_EVENT_GCALL) {
         I2C_RES->cb_event(ARM_I2C_EVENT_GENERAL_CALL | ARM_I2C_EVENT_TRANSFER_DONE);
 
     } else if (transfer->evt_sts & I2C_XFER_EVENT_BUS_CLEAR) {
-        transfer->cmd_bus_clr = false;
         I2C_RES->cb_event(ARM_I2C_EVENT_BUS_CLEAR);
 
     } else {
@@ -1252,6 +1731,21 @@ void I2C_HandleIRQStatus(I2C_RESOURCES *I2C_RES)
 void I2C_IRQHandler(I2C_RESOURCES *I2C_RES)
 {
     i2c_transfer_info_t *transfer = &(I2C_RES->transfer);
+
+    /* Stale-IRQ guard: an DMA abort cleanup path
+     * may have cleared curr_stat before the caller's unmask sequence
+     * runs. The resulting level-sensitive IRQ (TX_EMPTY, etc.) would
+     * re-enter forever. Silence it here.
+     */
+    if (transfer->curr_stat == I2C_XFER_NONE) {
+        i2c_mask_interrupt(I2C_RES->regs, 0xFFFFFFFFU);
+        i2c_clear_all_interrupt(I2C_RES->regs);
+        return;
+    }
+
+#if I2C_DMA_ENABLE
+    I2C_XFER_STATE prev_state = transfer->curr_stat;
+#endif
 
     /* Check for master mode */
     if (I2C_RES->mode == I2C_MASTER_MODE) {
@@ -1274,6 +1768,21 @@ void I2C_IRQHandler(I2C_RESOURCES *I2C_RES)
         }
     } /* Slave mode */
 
+#if I2C_DMA_ENABLE
+    /* Stop the DMA channel(s) when transfer completes via STOP_DET.
+     * TX transfers: stop TX channel. RX transfers: stop RX channel.
+     */
+    if (I2C_RES->dma_enable && (transfer->curr_stat == I2C_XFER_NONE)) {
+        if ((prev_state == I2C_XFER_MST_TX) || (prev_state == I2C_XFER_SLV_TX)
+             || (prev_state == I2C_XFER_MST_RX)) {
+            (void) I2C_DMA_Stop(&I2C_RES->dma_cfg->dma_tx);
+        }
+        if ((prev_state == I2C_XFER_MST_RX) || (prev_state == I2C_XFER_SLV_RX)) {
+            (void) I2C_DMA_Stop(&I2C_RES->dma_cfg->dma_rx);
+        }
+    }
+#endif
+
     /* Handle the status only if any event occurred */
     if (transfer->evt_sts != I2C_XFER_EVENT_NONE) {
         I2C_HandleIRQStatus(I2C_RES);
@@ -1291,15 +1800,187 @@ void I2C_IRQHandler(I2C_RESOURCES *I2C_RES)
  */
 static void I2C_DMACallback(uint32_t event, int8_t peri_num, I2C_RESOURCES *I2C)
 {
-    (void) peri_num;
-
     if (!I2C->cb_event) {
         return;
     }
 
-    /* Abort Occurred */
-    if (event & ARM_DMA_EVENT_ABORT) {
+    /* The I2C ISR owns end-of-transaction delivery. If it has already
+     * driven the transfer back to I2C_XFER_NONE (STOP_DET path), any DMA event
+     * arriving afterwards is a late echo.
+     */
+    if (I2C->transfer.curr_stat == I2C_XFER_NONE) {
+        return;
+    }
+
+    /* DMA ABORT: the I2C controller is wedged silently (no STOP_DET /
+     * TX_ABRT will fire on its own. Perform full inline teardown here so the
+     * driver can recover without depending on the I2C ISR.
+     */
+    if ((event & ARM_DMA_EVENT_ABORT) && (!I2C->transfer.abort)) {
+        uint32_t dma_count = 0U;
+
+        /* Mask all I2C IRQs first so stray events can't race teardown. */
+        i2c_mask_interrupt(I2C->regs, 0xFFFFFFFFU);
+
+        /* Stop both DMA channels */
+        (void) I2C_DMA_Stop(&I2C->dma_cfg->dma_tx);
+        (void) I2C_DMA_Stop(&I2C->dma_cfg->dma_rx);
+
+        /* Clear DMA enable bits on the I2C controller. */
+        i2c_disable_tx_dma(I2C->regs);
+        i2c_disable_rx_dma(I2C->regs);
+
+        /* Best-effort bus-release for master. Only set ABORT if the
+         * controller is currently active — ABORT is self-clearing only
+         * when the HW performs the abort. Setting it on an idle
+         * controller leaves the bit latched and silently aborts the
+         * *next* MasterTransmit/Receive.
+         */
+        if ((I2C->status.mode == I2C_MASTER_MODE) &&
+            ((I2C->regs->I2C_STATUS & I2C_IC_STATUS_MASTER_ACT) != 0U)) {
+            i2c_master_abort(I2C->regs);
+        }
+        /* Capture partial count for GetDataCount(). */
+        if (I2C->status.direction == I2C_DIR_TRANSMITTER) {
+            (void) I2C->dma_cfg->dma_tx.dma_drv->GetStatus(
+                       &I2C->dma_cfg->dma_tx.dma_handle, &dma_count);
+            I2C->transfer.curr_cnt += dma_count / 2U;
+        } else {
+            (void) I2C->dma_cfg->dma_rx.dma_drv->GetStatus(
+                       &I2C->dma_cfg->dma_rx.dma_handle, &dma_count);
+            I2C->transfer.curr_cnt = dma_count;
+        }
+
+        I2C->transfer.curr_stat = I2C_XFER_NONE;
+        I2C->dma_xfer_pending   = false;
+        I2C->status.busy        = 0U;
+
         I2C->cb_event(ARM_I2C_EVENT_TRANSFER_INCOMPLETE);
+
+        return;
+    }
+
+    /* TX-channel chunk completed. For transfers larger than one chunk we
+     * pack the next slice into scratch (TX-side) or generate the next
+     * READ_REQ batch (RX cmd issuance), rebuild microcode, and restart the
+     * channel.
+     *
+     * The final user event is delivered by the I2C ISR on STOP_DET
+     * (master) or the slave drain path — not by the DMA callback. When
+     * dma_xfer_remaining reaches 0 we do nothing here.
+     *
+     * Exception: when xfer_pending=true (RESTART requested), no STOP is
+     * sent, so STOP_DET never fires. In that case, we signal DONE here
+     * once the final chunk completes.
+     */
+    if (event & ARM_DMA_EVENT_COMPLETE) {
+        if ((I2C->dma_xfer_remaining > 0U) && (!I2C->transfer.abort)) {
+            switch (I2C->transfer.curr_stat) {
+            case I2C_XFER_MST_TX:
+                I2C->transfer.curr_cnt = I2C->dma_xfer_total - I2C->dma_xfer_remaining;
+                if (i2c_dma_tx_submit_chunk(I2C, true) != ARM_DRIVER_OK) {
+                    goto rearm_failed;
+                }
+                break;
+            case I2C_XFER_SLV_TX:
+                I2C->transfer.curr_cnt = I2C->dma_xfer_total - I2C->dma_xfer_remaining;
+                if (i2c_dma_tx_submit_chunk(I2C, false) != ARM_DRIVER_OK) {
+                    goto rearm_failed;
+                }
+                break;
+            case I2C_XFER_MST_RX:
+                /* Re-arm fires on TX-channel COMPLETE only; the RX-channel
+                 * COMPLETE arrives after the full drain finishes and at
+                 * that point dma_xfer_remaining is already 0.
+                 */
+                if (peri_num == I2C->dma_cfg->dma_tx.dma_periph_req) {
+                    I2C->transfer.curr_cnt = I2C->dma_xfer_total - I2C->dma_xfer_remaining;
+                    if (i2c_dma_rx_cmd_submit_chunk(I2C, 0U) != ARM_DRIVER_OK) {
+                        goto rearm_failed;
+                    }
+                }
+                break;
+            default:
+                break;
+            }
+            return;
+
+rearm_failed:
+            i2c_mask_interrupt(I2C->regs, 0xFFFFFFFFU);
+            (void) I2C_DMA_Stop(&I2C->dma_cfg->dma_tx);
+            (void) I2C_DMA_Stop(&I2C->dma_cfg->dma_rx);
+            i2c_disable_tx_dma(I2C->regs);
+            i2c_disable_rx_dma(I2C->regs);
+
+            if ((I2C->status.mode == I2C_MASTER_MODE) &&
+                ((I2C->regs->I2C_STATUS & I2C_IC_STATUS_MASTER_ACT) != 0U)) {
+                i2c_master_abort(I2C->regs);
+            }
+
+            I2C->transfer.curr_stat = I2C_XFER_NONE;
+            I2C->dma_xfer_pending   = false;
+            I2C->status.busy        = 0U;
+            I2C->cb_event(ARM_I2C_EVENT_TRANSFER_INCOMPLETE);
+            return;
+        } else if ((I2C->dma_xfer_remaining == 0U) &&
+                   (I2C->transfer.curr_stat == I2C_XFER_MST_TX) &&
+                   (I2C->dma_xfer_pending) &&
+                   (!I2C->transfer.abort)) {
+            /* xfer_pending=true: no STOP will be sent, so STOP_DET won't
+             * fire. Signal completion here instead.
+             */
+            i2c_master_disable_tx_interrupt(I2C->regs);
+            i2c_disable_tx_dma(I2C->regs);
+            I2C->transfer.curr_cnt  = I2C->dma_xfer_total;
+            I2C->transfer.curr_stat = I2C_XFER_NONE;
+            I2C->status.busy        = 0U;
+            I2C->cb_event(ARM_I2C_EVENT_TRANSFER_DONE);
+        } else if ((I2C->dma_xfer_remaining == 0U) &&
+                   (I2C->transfer.curr_stat == I2C_XFER_MST_RX) &&
+                   (I2C->dma_xfer_pending) &&
+                   (!I2C->transfer.abort)) {
+            /* xfer_pending=true: no STOP will be sent, so STOP_DET won't
+             * fire. Signal completion here instead.
+             */
+            if (peri_num == I2C->dma_cfg->dma_tx.dma_periph_req) {
+                /* TX channel completed first; RX channel will complete later */
+                i2c_master_disable_tx_interrupt(I2C->regs);
+                i2c_disable_tx_dma(I2C->regs);
+            } else {
+                i2c_master_disable_rx_interrupt(I2C->regs);
+                i2c_disable_rx_dma(I2C->regs);
+                I2C->transfer.curr_cnt  = I2C->dma_xfer_total;
+                I2C->transfer.curr_stat = I2C_XFER_NONE;
+                I2C->status.busy        = 0U;
+                I2C->cb_event(ARM_I2C_EVENT_TRANSFER_DONE);
+            }
+        } else if ((I2C->dma_xfer_remaining == 0U) &&
+                   (I2C->transfer.curr_stat == I2C_XFER_SLV_RX) &&
+                   (!I2C->transfer.abort)) {
+            /* Slave RX DMA completed all expected bytes. Signal DONE.
+             * Normally STOP_DET would signal completion, but in W/R combined
+             * mode the master sends RESTART instead of STOP.
+             */
+            i2c_slave_disable_rx_interrupt(I2C->regs);
+            i2c_disable_rx_dma(I2C->regs);
+            I2C->transfer.curr_cnt  = I2C->dma_xfer_total;
+            I2C->transfer.curr_stat = I2C_XFER_NONE;
+            I2C->status.busy        = 0U;
+            I2C->cb_event(ARM_I2C_EVENT_TRANSFER_DONE);
+        } else if ((I2C->dma_xfer_remaining == 0U) &&
+                   (I2C->transfer.curr_stat == I2C_XFER_SLV_TX) &&
+                   (!I2C->transfer.abort)) {
+            /* Slave TX DMA completed all expected bytes. Signal DONE.
+             * Normally STOP_DET would signal completion, but in W/R combined
+             * mode the master sends RESTART instead of STOP.
+             */
+            i2c_slave_disable_tx_interrupt(I2C->regs);
+            i2c_disable_tx_dma(I2C->regs);
+            I2C->transfer.curr_cnt  = I2C->dma_xfer_total;
+            I2C->transfer.curr_stat = I2C_XFER_NONE;
+            I2C->status.busy        = 0U;
+            I2C->cb_event(ARM_I2C_EVENT_TRANSFER_DONE);
+        }
     }
 }
 #endif
@@ -1308,6 +1989,7 @@ static void I2C_DMACallback(uint32_t event, int8_t peri_num, I2C_RESOURCES *I2C)
 #if (RTE_I2C0)
 
 #if RTE_I2C0_DMA_ENABLE
+static uint16_t I2C0_DMA_TX_SCRATCH[RTE_I2C0_DMA_SCRATCH_SIZE];
 static void I2C0_DMACallback(uint32_t event, int8_t peri_num);
 
 static I2C_DMA_HW_CONFIG I2C0_DMA_HW_CONFIG = {
@@ -1344,6 +2026,8 @@ static I2C_RESOURCES I2C0_RES = {
     .dma_irq_priority  = RTE_I2C0_DMA_IRQ_PRI,
     .dma_cb            = I2C0_DMACallback,
     .dma_cfg           = &I2C0_DMA_HW_CONFIG,
+    .dma_tx_scratch     = I2C0_DMA_TX_SCRATCH,
+    .dma_tx_scratch_sz  = RTE_I2C0_DMA_SCRATCH_SIZE,
 #endif
     .tx_fifo_threshold = RTE_I2C0_TX_FIFO_THRESHOLD,
     .rx_fifo_threshold = RTE_I2C0_RX_FIFO_THRESHOLD,
@@ -1435,6 +2119,7 @@ ARM_DRIVER_I2C        Driver_I2C0 = {
 #if (RTE_I2C1)
 
 #if RTE_I2C1_DMA_ENABLE
+static uint16_t I2C1_DMA_TX_SCRATCH[RTE_I2C1_DMA_SCRATCH_SIZE];
 static void I2C1_DMACallback(uint32_t event, int8_t peri_num);
 
 static I2C_DMA_HW_CONFIG I2C1_DMA_HW_CONFIG = {
@@ -1471,6 +2156,8 @@ static I2C_RESOURCES I2C1_RES = {
     .dma_irq_priority  = RTE_I2C1_DMA_IRQ_PRI,
     .dma_cb            = I2C1_DMACallback,
     .dma_cfg           = &I2C1_DMA_HW_CONFIG,
+    .dma_tx_scratch     = I2C1_DMA_TX_SCRATCH,
+    .dma_tx_scratch_sz  = RTE_I2C1_DMA_SCRATCH_SIZE,
 #endif
     .tx_fifo_threshold = RTE_I2C1_TX_FIFO_THRESHOLD,
     .rx_fifo_threshold = RTE_I2C1_RX_FIFO_THRESHOLD,
@@ -1562,6 +2249,7 @@ ARM_DRIVER_I2C        Driver_I2C1 = {
 #if (RTE_I2C2)
 
 #if RTE_I2C2_DMA_ENABLE
+static uint16_t I2C2_DMA_TX_SCRATCH[RTE_I2C2_DMA_SCRATCH_SIZE];
 static void I2C2_DMACallback(uint32_t event, int8_t peri_num);
 
 static I2C_DMA_HW_CONFIG I2C2_DMA_HW_CONFIG = {
@@ -1598,6 +2286,8 @@ static I2C_RESOURCES I2C2_RES = {
     .dma_irq_priority  = RTE_I2C2_DMA_IRQ_PRI,
     .dma_cb            = I2C2_DMACallback,
     .dma_cfg           = &I2C2_DMA_HW_CONFIG,
+    .dma_tx_scratch     = I2C2_DMA_TX_SCRATCH,
+    .dma_tx_scratch_sz  = RTE_I2C2_DMA_SCRATCH_SIZE,
 #endif
     .tx_fifo_threshold = RTE_I2C2_TX_FIFO_THRESHOLD,
     .rx_fifo_threshold = RTE_I2C2_RX_FIFO_THRESHOLD,
@@ -1689,6 +2379,7 @@ ARM_DRIVER_I2C        Driver_I2C2 = {
 #if (RTE_I2C3)
 
 #if RTE_I2C3_DMA_ENABLE
+static uint16_t I2C3_DMA_TX_SCRATCH[RTE_I2C3_DMA_SCRATCH_SIZE];
 static void I2C3_DMACallback(uint32_t event, int8_t peri_num);
 
 static I2C_DMA_HW_CONFIG I2C3_DMA_HW_CONFIG = {
@@ -1725,6 +2416,8 @@ static I2C_RESOURCES I2C3_RES = {
     .dma_irq_priority  = RTE_I2C3_DMA_IRQ_PRI,
     .dma_cb            = I2C3_DMACallback,
     .dma_cfg           = &I2C3_DMA_HW_CONFIG,
+    .dma_tx_scratch     = I2C3_DMA_TX_SCRATCH,
+    .dma_tx_scratch_sz  = RTE_I2C3_DMA_SCRATCH_SIZE,
 #endif
     .tx_fifo_threshold = RTE_I2C3_TX_FIFO_THRESHOLD,
     .rx_fifo_threshold = RTE_I2C3_RX_FIFO_THRESHOLD,
@@ -1816,6 +2509,7 @@ ARM_DRIVER_I2C        Driver_I2C3 = {
 #if (RTE_LPI2C1)
 
 #if RTE_LPI2C1_DMA_ENABLE
+static uint16_t LPI2C1_DMA_TX_SCRATCH[RTE_LPI2C1_DMA_SCRATCH_SIZE];
 static void LPI2C1_DMACallback(uint32_t event, int8_t peri_num);
 
 static I2C_DMA_HW_CONFIG LPI2C1_DMA_HW_CONFIG = {
@@ -1852,6 +2546,8 @@ static I2C_RESOURCES LPI2C1_RES = {
     .dma_irq_priority  = RTE_LPI2C1_DMA_IRQ_PRI,
     .dma_cb            = LPI2C1_DMACallback,
     .dma_cfg           = &LPI2C1_DMA_HW_CONFIG,
+    .dma_tx_scratch     = LPI2C1_DMA_TX_SCRATCH,
+    .dma_tx_scratch_sz  = RTE_LPI2C1_DMA_SCRATCH_SIZE,
 #endif
     .tx_fifo_threshold = RTE_LPI2C1_TX_FIFO_THRESHOLD,
     .rx_fifo_threshold = RTE_LPI2C1_RX_FIFO_THRESHOLD,

--- a/Alif_CMSIS/Source/Driver_I2C.c
+++ b/Alif_CMSIS/Source/Driver_I2C.c
@@ -1791,6 +1791,60 @@ void I2C_IRQHandler(I2C_RESOURCES *I2C_RES)
 
 #if I2C_DMA_ENABLE
 
+typedef enum {
+    I2C_DMA_DRAIN_DONE,    /* bus went idle cleanly — caller emits TRANSFER_DONE */
+    I2C_DMA_DRAIN_ABORT,   /* TX_ABRT latched — caller returns without emit so the
+                            * pending I2C ISR delivers the error event
+                            */
+    I2C_DMA_DRAIN_TIMEOUT, /* ~3 ms elapsed — caller emits BUS_ERROR | INCOMPLETE  */
+} i2c_dma_drain_result_t;
+
+/* Bound on the FIFO+shift-register drain. Worst case is Standard mode
+ * (100 kHz) with a full 32-deep TX FIFO: 32 * 90 us ≈ 2.88 ms.
+ */
+#define I2C_DMA_DRAIN_TIMEOUT_US 3000U
+
+/* sys_busy_loop_us() resolves to a single tick (~30.51 us) */
+#define I2C_DMA_DRAIN_POLL_STEP_US 30U
+#define I2C_DMA_DRAIN_MAX_ITERS                                                                    \
+    ((I2C_DMA_DRAIN_TIMEOUT_US + I2C_DMA_DRAIN_POLL_STEP_US - 1U) / I2C_DMA_DRAIN_POLL_STEP_US)
+
+/* One Standard-mode (100 kHz) byte time covers the shift register tail
+ * after IC_STATUS.TFE asserts. Faster modes finish sooner; the extra
+ * wait is harmless.
+ */
+#define I2C_DMA_SHIFT_TAIL_US 90U
+
+/* Poll for the FIFO+shift-register drain that follows DMA COMPLETE on a
+ * TX transfer. DMA COMPLETE only means the bytes are
+ * in the I2C TX FIFO; the controller may still be clocking them onto SDA
+ * and a late slave NACK or arbitration loss raises TX_ABRT *after* DMA
+ * reports success.
+ *
+ * Called from the DMA ISR — the I2C ISR cannot run until this returns,
+ * so we inspect IC_STATUS / IC_RAW_INTR_STAT directly instead of waiting
+ * for the TX_ABRT handler. TFE reports FIFO empty but not shift-register
+ * empty, hence the fixed ~90 us tail wait on the clean path.
+ */
+static i2c_dma_drain_result_t i2c_dma_wait_drain(I2C_RESOURCES *I2C)
+{
+    for (uint32_t i = 0U; i < I2C_DMA_DRAIN_MAX_ITERS; i++) {
+        if (i2c_tx_abort_pending(I2C->regs)) {
+            return I2C_DMA_DRAIN_ABORT;
+        }
+        if (i2c_tx_fifo_empty(I2C->regs)) {
+            sys_busy_loop_us(I2C_DMA_SHIFT_TAIL_US);
+            /* Re-check for an abort that fired during the tail wait. */
+            if (i2c_tx_abort_pending(I2C->regs)) {
+                return I2C_DMA_DRAIN_ABORT;
+            }
+            return I2C_DMA_DRAIN_DONE;
+        }
+        sys_busy_loop_us(I2C_DMA_DRAIN_POLL_STEP_US);
+    }
+    return I2C_DMA_DRAIN_TIMEOUT;
+}
+
 /**
  * @brief   Callback function from DMA for I2C
  * @param   event    : Event from DMA
@@ -1927,14 +1981,38 @@ rearm_failed:
                    (I2C->dma_xfer_pending) &&
                    (!I2C->transfer.abort)) {
             /* xfer_pending=true: no STOP will be sent, so STOP_DET won't
-             * fire. Signal completion here instead.
+             * fire. Wait for the FIFO+shift-register drain to finish
+             * before signalling completion. A late TX_ABRT raised during
+             * drain is delivered via the pending I2C ISR by returning
+             * from this DMA cb without emit (interrupts must stay
+             * unmasked until then, so the disable+emit only happens on
+             * the clean-drain path).
              */
-            i2c_master_disable_tx_interrupt(I2C->regs);
-            i2c_disable_tx_dma(I2C->regs);
-            I2C->transfer.curr_cnt  = I2C->dma_xfer_total;
-            I2C->transfer.curr_stat = I2C_XFER_NONE;
-            I2C->status.busy        = 0U;
-            I2C->cb_event(ARM_I2C_EVENT_TRANSFER_DONE);
+            switch (i2c_dma_wait_drain(I2C)) {
+            case I2C_DMA_DRAIN_ABORT:
+                /* Pending I2C TX_ABRT ISR routes through HandleIRQError. */
+                return;
+            case I2C_DMA_DRAIN_TIMEOUT:
+                i2c_master_disable_tx_interrupt(I2C->regs);
+                i2c_disable_tx_dma(I2C->regs);
+                I2C->status.bus_error   = 1U;
+                I2C->transfer.curr_cnt  = I2C->dma_xfer_total -
+                                          i2c_tx_fifo_level(I2C->regs);
+                I2C->transfer.curr_stat = I2C_XFER_NONE;
+                I2C->status.busy        = 0U;
+                I2C->cb_event(ARM_I2C_EVENT_BUS_ERROR |
+                              ARM_I2C_EVENT_TRANSFER_INCOMPLETE);
+                break;
+            case I2C_DMA_DRAIN_DONE:
+            default:
+                i2c_master_disable_tx_interrupt(I2C->regs);
+                i2c_disable_tx_dma(I2C->regs);
+                I2C->transfer.curr_cnt  = I2C->dma_xfer_total;
+                I2C->transfer.curr_stat = I2C_XFER_NONE;
+                I2C->status.busy        = 0U;
+                I2C->cb_event(ARM_I2C_EVENT_TRANSFER_DONE);
+                break;
+            }
         } else if ((I2C->dma_xfer_remaining == 0U) &&
                    (I2C->transfer.curr_stat == I2C_XFER_MST_RX) &&
                    (I2C->dma_xfer_pending) &&
@@ -1970,16 +2048,39 @@ rearm_failed:
         } else if ((I2C->dma_xfer_remaining == 0U) &&
                    (I2C->transfer.curr_stat == I2C_XFER_SLV_TX) &&
                    (!I2C->transfer.abort)) {
-            /* Slave TX DMA completed all expected bytes. Signal DONE.
-             * Normally STOP_DET would signal completion, but in W/R combined
-             * mode the master sends RESTART instead of STOP.
+            /* Slave TX DMA finished pushing all bytes into the TX FIFO.
+             * When the master is using xfer_pending master-RX, no STOP
+             * fires and STOP_DET will not signal completion, so the DMA
+             * cb must emit it. Wait for FIFO+shift drain first so a late
+             * TX_ABRT (arbitration loss, slave-flush, etc.) is delivered
+             * via the pending I2C ISR through HandleIRQError instead of
+             * being masked by a premature TRANSFER_DONE.
              */
-            i2c_slave_disable_tx_interrupt(I2C->regs);
-            i2c_disable_tx_dma(I2C->regs);
-            I2C->transfer.curr_cnt  = I2C->dma_xfer_total;
-            I2C->transfer.curr_stat = I2C_XFER_NONE;
-            I2C->status.busy        = 0U;
-            I2C->cb_event(ARM_I2C_EVENT_TRANSFER_DONE);
+            switch (i2c_dma_wait_drain(I2C)) {
+            case I2C_DMA_DRAIN_ABORT:
+                /* Pending I2C TX_ABRT ISR routes through HandleIRQError. */
+                return;
+            case I2C_DMA_DRAIN_TIMEOUT:
+                i2c_slave_disable_tx_interrupt(I2C->regs);
+                i2c_disable_tx_dma(I2C->regs);
+                I2C->status.bus_error   = 1U;
+                I2C->transfer.curr_cnt  = I2C->dma_xfer_total -
+                                          i2c_tx_fifo_level(I2C->regs);
+                I2C->transfer.curr_stat = I2C_XFER_NONE;
+                I2C->status.busy        = 0U;
+                I2C->cb_event(ARM_I2C_EVENT_BUS_ERROR |
+                              ARM_I2C_EVENT_TRANSFER_INCOMPLETE);
+                break;
+            case I2C_DMA_DRAIN_DONE:
+            default:
+                i2c_slave_disable_tx_interrupt(I2C->regs);
+                i2c_disable_tx_dma(I2C->regs);
+                I2C->transfer.curr_cnt  = I2C->dma_xfer_total;
+                I2C->transfer.curr_stat = I2C_XFER_NONE;
+                I2C->status.busy        = 0U;
+                I2C->cb_event(ARM_I2C_EVENT_TRANSFER_DONE);
+                break;
+            }
         }
     }
 }

--- a/Alif_CMSIS/Source/Driver_I2C.c
+++ b/Alif_CMSIS/Source/Driver_I2C.c
@@ -1250,8 +1250,14 @@ static int32_t ARM_I2C_SlaveTransmit(I2C_RESOURCES *I2C, const uint8_t *data, ui
     I2C->transfer.tx_over        = 0U;
     I2C->transfer.curr_stat      = I2C_XFER_SLV_TX;
 
-    /* Clear all interrupts */
-    i2c_clear_all_interrupt(I2C->regs);
+    /* Clear stale software-clearable interrupts from a previous transaction
+     * WITHOUT touching RD_REQ. CLR_INTR would clear a pending RD_REQ
+     * latched when the master started its read phase mid-transaction (e.g.
+     * WRITE + RESTART + READ, where the app arms SlaveTransmit after
+     * SlaveReceive has completed).
+     */
+    (void) I2C->regs->I2C_CLR_TX_ABRT;
+    (void) I2C->regs->I2C_CLR_STOP_DET;
 
 #if I2C_DMA_ENABLE
     if (I2C->dma_enable) {

--- a/Alif_CMSIS/Source/Driver_I2C.c
+++ b/Alif_CMSIS/Source/Driver_I2C.c
@@ -1076,50 +1076,30 @@ static int32_t ARM_I2C_Control(I2C_RESOURCES *I2C, uint32_t control, uint32_t ar
 
     case ARM_I2C_ABORT_TRANSFER:
 
-#if I2C_DMA_ENABLE
-        if (I2C->dma_enable) {
-            /* Transmit mode */
-            if (I2C->status.direction == I2C_DIR_TRANSMITTER) {
-                if (I2C_DMA_Stop(&I2C->dma_cfg->dma_tx) != ARM_DRIVER_OK) {
-                    return ARM_DRIVER_ERROR;
-                }
-            } else if (I2C->status.direction == I2C_DIR_RECEIVER) { /* Reception mode */
-                if (I2C_DMA_Stop(&I2C->dma_cfg->dma_rx) != ARM_DRIVER_OK) {
-                    return ARM_DRIVER_ERROR;
-                }
-            }
-
-            i2c_disable_tx_dma(I2C->regs);
-            i2c_disable_rx_dma(I2C->regs);
+        /* I2C protocol: only the master can terminate a bus cycle */
+        if (I2C->mode != I2C_MASTER_MODE) {
+            return ARM_DRIVER_ERROR_UNSUPPORTED;
         }
-#endif
-        /* only useful in interrupt method,
-         * no effect on polling method.
-         */
 
-        /* i2c is half-duplex, at a time it can be either tx or rx
-         * not sure which one is running, so clearing both. */
+        /* Mark abort early so DMA callback / ISR won't overwrite curr_cnt */
+        I2C->transfer.abort = true;
 
-        /* if tx interrupt flag is enable then only disable transmit interrupt */
-        if (I2C->mode == I2C_MASTER_MODE) {
+        if (I2C->status.busy) {
+            /* Active master transfer: emit TX_ABRT(USER_ABRT) +
+             * STOP_DET; the ISR handles teardown and app callback.
+             */
+            i2c_master_abort(I2C->regs);
+        } else {
+            /* No active transfer: local cleanup only. */
             i2c_master_disable_tx_interrupt(I2C->regs);
-        } else {
-            i2c_slave_disable_tx_interrupt(I2C->regs);
-        }
-
-        if (I2C->mode == I2C_MASTER_MODE) {
             i2c_master_disable_rx_interrupt(I2C->regs);
-        } else {
-            i2c_slave_disable_rx_interrupt(I2C->regs);
+
+            I2C->transfer.tx_total_num = 0U;
+            I2C->transfer.rx_total_num = 0U;
+            I2C->transfer.curr_stat    = I2C_XFER_NONE;
+            I2C->transfer.abort        = false;
+            I2C->status.busy           = 0U;
         }
-
-        /* Reset the tx_buffer */
-        I2C->transfer.tx_total_num = 0U;
-        I2C->transfer.rx_total_num = 0U;
-        I2C->transfer.curr_stat    = I2C_XFER_NONE;
-
-        /* clear busy status bit. */
-        I2C->status.busy           = 0U;
 
         break;
 

--- a/Alif_CMSIS/Source/Driver_I2C_Private.h
+++ b/Alif_CMSIS/Source/Driver_I2C_Private.h
@@ -35,9 +35,9 @@
 #if I2C_DMA_ENABLE
 /* Microcode buffer size for the per-instance TX and RX microcodes.
  * Sized for a single DMALP chunk (max 256 iterations):
- * 64 B fits the worst case.
+ * 96 B fits the worst case.
  */
-#define I2C_DMA_MCODE_SIZE 64
+#define I2C_DMA_MCODE_SIZE 96
 #endif
 
 typedef volatile struct _I2C_DRIVER_STATE {

--- a/Alif_CMSIS/Source/Driver_I2C_Private.h
+++ b/Alif_CMSIS/Source/Driver_I2C_Private.h
@@ -29,6 +29,15 @@
 
 #if I2C_DMA_ENABLE
 #include <DMA_Common.h>
+#include "dma_opcode.h"
+#endif
+
+#if I2C_DMA_ENABLE
+/* Microcode buffer size for the per-instance TX and RX microcodes.
+ * Sized for a single DMALP chunk (max 256 iterations):
+ * 64 B fits the worst case.
+ */
+#define I2C_DMA_MCODE_SIZE 64
 #endif
 
 typedef volatile struct _I2C_DRIVER_STATE {
@@ -68,6 +77,13 @@ typedef struct _I2C_RESOURCES {
     const uint32_t        dma_irq_priority; /* DMA IRQ priority number                 */
     ARM_DMA_SignalEvent_t dma_cb;           /* I2S DMA Callback                        */
     I2C_DMA_HW_CONFIG    *dma_cfg;          /* DMA Controller configuration            */
+    uint16_t             *dma_tx_scratch;    /* 16-bit DATA_CMD scratch buf            */
+    uint32_t              dma_tx_scratch_sz; /* Scratch buf capacity                   */
+    const uint8_t        *dma_xfer_src;     /* Pointer into the user's 8-bit TX buffer */
+    uint32_t              dma_xfer_remaining; /* Bytes left after the current chunk    */
+    uint32_t              dma_xfer_total;   /* Original transfer size                  */
+    bool                  dma_xfer_pending; /* If true, no STOP on final chunk         */
+    uint8_t               dma_mcode[I2C_DMA_MCODE_SIZE] __ALIGNED(32); /* microcode    */
 #endif
     uint8_t            tx_fifo_threshold; /* Tx Fifo Buffer threshold                */
     uint8_t            rx_fifo_threshold; /* Rx Fifo Buffer threshold                */

--- a/Boards/Templates/Baremetal/demo_i2c.c
+++ b/Boards/Templates/Baremetal/demo_i2c.c
@@ -71,53 +71,7 @@ static volatile uint32_t slv_cb_status;
 #endif
 
 #define STOP (0X00)
-#if (RTE_I2C0_DMA_ENABLE && RTE_I2C1_DMA_ENABLE)
-#define I2C_DMA_ENABLED 1
-#else
-#define I2C_DMA_ENABLED 0
-#endif
-#if I2C_DMA_ENABLED
-/* master transmit and slave receive */
-#define MST_BYTE_TO_TRANSMIT 11
-/* slave transmit and master receive */
-#define SLV_BYTE_TO_TRANSMIT 10
-/* Tx and Rx buffers are in multiples of 2bytes
- * as the DMA processes in 2bytes fashion only */
-/* Master parameter set */
-/* Master TX Data */
-static uint16_t __ALIGNED(4) MST_TX_BUF[MST_BYTE_TO_TRANSMIT] = {
-    /* MST_TX_BUF data = "Master_Data" */
-    77,
-    97,
-    115,
-    116,
-    101,
-    114,
-    95,
-    68,
-    97,
-    116,
-    97};
-/* master receive buffer */
-static uint16_t __ALIGNED(4) MST_RX_BUF[SLV_BYTE_TO_TRANSMIT];
-/* Master parameter set END  */
-/* Slave parameter set */
-/* slave receive buffer */
-static uint16_t __ALIGNED(4) SLV_RX_BUF[MST_BYTE_TO_TRANSMIT];
-static uint16_t __ALIGNED(4) SLV_TX_BUF[SLV_BYTE_TO_TRANSMIT] = {
-    /* SLV_TX_BUF data =  "Slave_Data" */
-    83,
-    108,
-    97,
-    118,
-    101,
-    95,
-    68,
-    97,
-    116,
-    97};
-/* Slave parameter set END */
-#else
+
 /* master transmit and slave receive */
 #define MST_BYTE_TO_TRANSMIT 30
 /* slave transmit and master receive */
@@ -134,7 +88,7 @@ static uint8_t SLV_RX_BUF[MST_BYTE_TO_TRANSMIT];
 /* Slave TX Data */
 static uint8_t SLV_TX_BUF[SLV_BYTE_TO_TRANSMIT] = {"!*!Test Message from Slave!*!"};
 /* Slave parameter set END */
-#endif
+
 
 typedef enum _I2C_CB_EVENT {
     I2C_CB_EVENT_TRANSFER_DONE       = (1 << 0),
@@ -309,11 +263,7 @@ static void I2C_demo(void)
     }
 
     /* Compare received data. */
-#if I2C_DMA_ENABLED
-    if (memcmp(&SLV_RX_BUF, &MST_TX_BUF, (MST_BYTE_TO_TRANSMIT * 2)))
-#else
     if (memcmp(&SLV_RX_BUF, &MST_TX_BUF, MST_BYTE_TO_TRANSMIT))
-#endif
     {
         printf("\n Error: Master transmit/slave receive failed \n");
         printf("\n ---Stop--- \r\n wait forever >>> \n");
@@ -371,11 +321,7 @@ static void I2C_demo(void)
     sys_busy_loop_us(1000);
 
     /* Compare received data. */
-#if I2C_DMA_ENABLED
-    if (memcmp(&SLV_TX_BUF, &MST_RX_BUF, (SLV_BYTE_TO_TRANSMIT * 2)))
-#else
     if (memcmp(&SLV_TX_BUF, &MST_RX_BUF, SLV_BYTE_TO_TRANSMIT))
-#endif
     {
         printf("\n Error: Master receive/slave transmit failed\n");
         printf("\n ---Stop--- \r\n wait forever >>> \n");

--- a/Device/soc/AE1C1F4051920/rte/RTE_Device.h
+++ b/Device/soc/AE1C1F4051920/rte/RTE_Device.h
@@ -3626,6 +3626,12 @@
 // <i> Defines I2C0 DMA Interrupt priority
 // <i> Default: 0
 #define RTE_I2C0_DMA_IRQ_PRI 0
+
+// <o> I2C0 DMA scratch buffer size (entries) <32-256:8>
+// <i> Per-instance 16-bit DMA scratch buffer; sized in DATA_CMD entries.
+// <i> Caps the per-chunk DMA transfer (max 256).
+// <i> Default: 256
+#define RTE_I2C0_DMA_SCRATCH_SIZE 256
 #endif
 
 #endif
@@ -3663,6 +3669,12 @@
 // <i> Defines I2C1 DMA Interrupt priority
 // <i> Default: 0
 #define RTE_I2C1_DMA_IRQ_PRI 0
+
+// <o> I2C1 DMA scratch buffer size (entries) <32-256:8>
+// <i> Per-instance 16-bit DMA scratch buffer; sized in DATA_CMD entries.
+// <i> Caps the per-chunk DMA transfer (max 256).
+// <i> Default: 256
+#define RTE_I2C1_DMA_SCRATCH_SIZE 256
 #endif
 
 #endif

--- a/Device/soc/AE302F80F5582/rte/RTE_Device.h
+++ b/Device/soc/AE302F80F5582/rte/RTE_Device.h
@@ -8130,6 +8130,12 @@
 // <i> Defines I2C0 DMA Interrupt priority
 // <i> Default: 0
 #define RTE_I2C0_DMA_IRQ_PRI 0
+
+// <o> I2C0 DMA scratch buffer size (entries) <32-256:8>
+// <i> Per-instance 16-bit DMA scratch buffer; sized in DATA_CMD entries.
+// <i> Caps the per-chunk DMA transfer (max 256).
+// <i> Default: 256
+#define RTE_I2C0_DMA_SCRATCH_SIZE 256
 #endif
 
 #endif
@@ -8167,6 +8173,12 @@
 // <i> Defines I2C1 DMA Interrupt priority
 // <i> Default: 0
 #define RTE_I2C1_DMA_IRQ_PRI 0
+
+// <o> I2C1 DMA scratch buffer size (entries) <32-256:8>
+// <i> Per-instance 16-bit DMA scratch buffer; sized in DATA_CMD entries.
+// <i> Caps the per-chunk DMA transfer (max 256).
+// <i> Default: 256
+#define RTE_I2C1_DMA_SCRATCH_SIZE 256
 #endif
 
 #endif
@@ -8204,6 +8216,12 @@
 // <i> Defines I2C2 DMA Interrupt priority
 // <i> Default: 0
 #define RTE_I2C2_DMA_IRQ_PRI 0
+
+// <o> I2C2 DMA scratch buffer size (entries) <32-256:8>
+// <i> Per-instance 16-bit DMA scratch buffer; sized in DATA_CMD entries.
+// <i> Caps the per-chunk DMA transfer (max 256).
+// <i> Default: 256
+#define RTE_I2C2_DMA_SCRATCH_SIZE 256
 #endif
 
 #endif
@@ -8242,6 +8260,12 @@
 // <i> Defines I2C3 DMA Interrupt priority
 // <i> Default: 0
 #define RTE_I2C3_DMA_IRQ_PRI 0
+
+// <o> I2C3 DMA scratch buffer size (entries) <32-256:8>
+// <i> Per-instance 16-bit DMA scratch buffer; sized in DATA_CMD entries.
+// <i> Caps the per-chunk DMA transfer (max 256).
+// <i> Default: 256
+#define RTE_I2C3_DMA_SCRATCH_SIZE 256
 #endif
 
 #endif

--- a/Device/soc/AE302F80F55D5/rte/RTE_Device.h
+++ b/Device/soc/AE302F80F55D5/rte/RTE_Device.h
@@ -8130,6 +8130,12 @@
 // <i> Defines I2C0 DMA Interrupt priority
 // <i> Default: 0
 #define RTE_I2C0_DMA_IRQ_PRI 0
+
+// <o> I2C0 DMA scratch buffer size (entries) <32-256:8>
+// <i> Per-instance 16-bit DMA scratch buffer; sized in DATA_CMD entries.
+// <i> Caps the per-chunk DMA transfer (max 256).
+// <i> Default: 256
+#define RTE_I2C0_DMA_SCRATCH_SIZE 256
 #endif
 
 #endif
@@ -8167,6 +8173,12 @@
 // <i> Defines I2C1 DMA Interrupt priority
 // <i> Default: 0
 #define RTE_I2C1_DMA_IRQ_PRI 0
+
+// <o> I2C1 DMA scratch buffer size (entries) <32-256:8>
+// <i> Per-instance 16-bit DMA scratch buffer; sized in DATA_CMD entries.
+// <i> Caps the per-chunk DMA transfer (max 256).
+// <i> Default: 256
+#define RTE_I2C1_DMA_SCRATCH_SIZE 256
 #endif
 
 #endif
@@ -8204,6 +8216,12 @@
 // <i> Defines I2C2 DMA Interrupt priority
 // <i> Default: 0
 #define RTE_I2C2_DMA_IRQ_PRI 0
+
+// <o> I2C2 DMA scratch buffer size (entries) <32-256:8>
+// <i> Per-instance 16-bit DMA scratch buffer; sized in DATA_CMD entries.
+// <i> Caps the per-chunk DMA transfer (max 256).
+// <i> Default: 256
+#define RTE_I2C2_DMA_SCRATCH_SIZE 256
 #endif
 
 #endif
@@ -8242,6 +8260,12 @@
 // <i> Defines I2C3 DMA Interrupt priority
 // <i> Default: 0
 #define RTE_I2C3_DMA_IRQ_PRI 0
+
+// <o> I2C3 DMA scratch buffer size (entries) <32-256:8>
+// <i> Per-instance 16-bit DMA scratch buffer; sized in DATA_CMD entries.
+// <i> Caps the per-chunk DMA transfer (max 256).
+// <i> Default: 256
+#define RTE_I2C3_DMA_SCRATCH_SIZE 256
 #endif
 
 #endif

--- a/Device/soc/AE402FA0E5597/rte/RTE_Device.h
+++ b/Device/soc/AE402FA0E5597/rte/RTE_Device.h
@@ -9081,6 +9081,12 @@
 // <i> Defines I2C0 DMA Interrupt priority
 // <i> Default: 0
 #define RTE_I2C0_DMA_IRQ_PRI 0
+
+// <o> I2C0 DMA scratch buffer size (entries) <32-256:8>
+// <i> Per-instance 16-bit DMA scratch buffer; sized in DATA_CMD entries.
+// <i> Caps the per-chunk DMA transfer (max 256).
+// <i> Default: 256
+#define RTE_I2C0_DMA_SCRATCH_SIZE 256
 #endif
 
 #endif
@@ -9118,6 +9124,12 @@
 // <i> Defines I2C1 DMA Interrupt priority
 // <i> Default: 0
 #define RTE_I2C1_DMA_IRQ_PRI 0
+
+// <o> I2C1 DMA scratch buffer size (entries) <32-256:8>
+// <i> Per-instance 16-bit DMA scratch buffer; sized in DATA_CMD entries.
+// <i> Caps the per-chunk DMA transfer (max 256).
+// <i> Default: 256
+#define RTE_I2C1_DMA_SCRATCH_SIZE 256
 #endif
 
 #endif
@@ -9155,6 +9167,12 @@
 // <i> Defines I2C2 DMA Interrupt priority
 // <i> Default: 0
 #define RTE_I2C2_DMA_IRQ_PRI 0
+
+// <o> I2C2 DMA scratch buffer size (entries) <32-256:8>
+// <i> Per-instance 16-bit DMA scratch buffer; sized in DATA_CMD entries.
+// <i> Caps the per-chunk DMA transfer (max 256).
+// <i> Default: 256
+#define RTE_I2C2_DMA_SCRATCH_SIZE 256
 #endif
 
 #endif
@@ -9193,6 +9211,12 @@
 // <i> Defines I2C3 DMA Interrupt priority
 // <i> Default: 0
 #define RTE_I2C3_DMA_IRQ_PRI 0
+
+// <o> I2C3 DMA scratch buffer size (entries) <32-256:8>
+// <i> Per-instance 16-bit DMA scratch buffer; sized in DATA_CMD entries.
+// <i> Caps the per-chunk DMA transfer (max 256).
+// <i> Default: 256
+#define RTE_I2C3_DMA_SCRATCH_SIZE 256
 #endif
 
 #endif
@@ -9250,6 +9274,12 @@
 // <i> Defines LPI2C1 DMA Interrupt priority
 // <i> Default: 0
 #define RTE_LPI2C1_DMA_IRQ_PRI 0
+
+// <o> LPI2C1 DMA scratch buffer size (entries) <32-256:8>
+// <i> Per-instance 16-bit DMA scratch buffer; sized in DATA_CMD entries.
+// <i> Caps the per-chunk DMA transfer (max 256).
+// <i> Default: 256
+#define RTE_LPI2C1_DMA_SCRATCH_SIZE 256
 #endif
 
 #endif

--- a/Device/soc/AE512F80F5582/rte/RTE_Device.h
+++ b/Device/soc/AE512F80F5582/rte/RTE_Device.h
@@ -8130,6 +8130,12 @@
 // <i> Defines I2C0 DMA Interrupt priority
 // <i> Default: 0
 #define RTE_I2C0_DMA_IRQ_PRI 0
+
+// <o> I2C0 DMA scratch buffer size (entries) <32-256:8>
+// <i> Per-instance 16-bit DMA scratch buffer; sized in DATA_CMD entries.
+// <i> Caps the per-chunk DMA transfer (max 256).
+// <i> Default: 256
+#define RTE_I2C0_DMA_SCRATCH_SIZE 256
 #endif
 
 #endif
@@ -8167,6 +8173,12 @@
 // <i> Defines I2C1 DMA Interrupt priority
 // <i> Default: 0
 #define RTE_I2C1_DMA_IRQ_PRI 0
+
+// <o> I2C1 DMA scratch buffer size (entries) <32-256:8>
+// <i> Per-instance 16-bit DMA scratch buffer; sized in DATA_CMD entries.
+// <i> Caps the per-chunk DMA transfer (max 256).
+// <i> Default: 256
+#define RTE_I2C1_DMA_SCRATCH_SIZE 256
 #endif
 
 #endif
@@ -8204,6 +8216,12 @@
 // <i> Defines I2C2 DMA Interrupt priority
 // <i> Default: 0
 #define RTE_I2C2_DMA_IRQ_PRI 0
+
+// <o> I2C2 DMA scratch buffer size (entries) <32-256:8>
+// <i> Per-instance 16-bit DMA scratch buffer; sized in DATA_CMD entries.
+// <i> Caps the per-chunk DMA transfer (max 256).
+// <i> Default: 256
+#define RTE_I2C2_DMA_SCRATCH_SIZE 256
 #endif
 
 #endif
@@ -8242,6 +8260,12 @@
 // <i> Defines I2C3 DMA Interrupt priority
 // <i> Default: 0
 #define RTE_I2C3_DMA_IRQ_PRI 0
+
+// <o> I2C3 DMA scratch buffer size (entries) <32-256:8>
+// <i> Per-instance 16-bit DMA scratch buffer; sized in DATA_CMD entries.
+// <i> Caps the per-chunk DMA transfer (max 256).
+// <i> Default: 256
+#define RTE_I2C3_DMA_SCRATCH_SIZE 256
 #endif
 
 #endif

--- a/Device/soc/AE512F80F55D5/rte/RTE_Device.h
+++ b/Device/soc/AE512F80F55D5/rte/RTE_Device.h
@@ -8130,6 +8130,12 @@
 // <i> Defines I2C0 DMA Interrupt priority
 // <i> Default: 0
 #define RTE_I2C0_DMA_IRQ_PRI 0
+
+// <o> I2C0 DMA scratch buffer size (entries) <32-256:8>
+// <i> Per-instance 16-bit DMA scratch buffer; sized in DATA_CMD entries.
+// <i> Caps the per-chunk DMA transfer (max 256).
+// <i> Default: 256
+#define RTE_I2C0_DMA_SCRATCH_SIZE 256
 #endif
 
 #endif
@@ -8167,6 +8173,12 @@
 // <i> Defines I2C1 DMA Interrupt priority
 // <i> Default: 0
 #define RTE_I2C1_DMA_IRQ_PRI 0
+
+// <o> I2C1 DMA scratch buffer size (entries) <32-256:8>
+// <i> Per-instance 16-bit DMA scratch buffer; sized in DATA_CMD entries.
+// <i> Caps the per-chunk DMA transfer (max 256).
+// <i> Default: 256
+#define RTE_I2C1_DMA_SCRATCH_SIZE 256
 #endif
 
 #endif
@@ -8204,6 +8216,12 @@
 // <i> Defines I2C2 DMA Interrupt priority
 // <i> Default: 0
 #define RTE_I2C2_DMA_IRQ_PRI 0
+
+// <o> I2C2 DMA scratch buffer size (entries) <32-256:8>
+// <i> Per-instance 16-bit DMA scratch buffer; sized in DATA_CMD entries.
+// <i> Caps the per-chunk DMA transfer (max 256).
+// <i> Default: 256
+#define RTE_I2C2_DMA_SCRATCH_SIZE 256
 #endif
 
 #endif
@@ -8242,6 +8260,12 @@
 // <i> Defines I2C3 DMA Interrupt priority
 // <i> Default: 0
 #define RTE_I2C3_DMA_IRQ_PRI 0
+
+// <o> I2C3 DMA scratch buffer size (entries) <32-256:8>
+// <i> Per-instance 16-bit DMA scratch buffer; sized in DATA_CMD entries.
+// <i> Caps the per-chunk DMA transfer (max 256).
+// <i> Default: 256
+#define RTE_I2C3_DMA_SCRATCH_SIZE 256
 #endif
 
 #endif

--- a/Device/soc/AE722F80F55D5/rte/RTE_Device.h
+++ b/Device/soc/AE722F80F55D5/rte/RTE_Device.h
@@ -8079,6 +8079,12 @@
 // <i> Defines I2C0 DMA Interrupt priority
 // <i> Default: 0
 #define RTE_I2C0_DMA_IRQ_PRI 0
+
+// <o> I2C0 DMA scratch buffer size (entries) <32-256:8>
+// <i> Per-instance 16-bit DMA scratch buffer; sized in DATA_CMD entries.
+// <i> Caps the per-chunk DMA transfer (max 256).
+// <i> Default: 256
+#define RTE_I2C0_DMA_SCRATCH_SIZE 256
 #endif
 
 #endif
@@ -8116,6 +8122,12 @@
 // <i> Defines I2C1 DMA Interrupt priority
 // <i> Default: 0
 #define RTE_I2C1_DMA_IRQ_PRI 0
+
+// <o> I2C1 DMA scratch buffer size (entries) <32-256:8>
+// <i> Per-instance 16-bit DMA scratch buffer; sized in DATA_CMD entries.
+// <i> Caps the per-chunk DMA transfer (max 256).
+// <i> Default: 256
+#define RTE_I2C1_DMA_SCRATCH_SIZE 256
 #endif
 
 #endif
@@ -8153,6 +8165,12 @@
 // <i> Defines I2C2 DMA Interrupt priority
 // <i> Default: 0
 #define RTE_I2C2_DMA_IRQ_PRI 0
+
+// <o> I2C2 DMA scratch buffer size (entries) <32-256:8>
+// <i> Per-instance 16-bit DMA scratch buffer; sized in DATA_CMD entries.
+// <i> Caps the per-chunk DMA transfer (max 256).
+// <i> Default: 256
+#define RTE_I2C2_DMA_SCRATCH_SIZE 256
 #endif
 
 #endif
@@ -8191,6 +8209,12 @@
 // <i> Defines I2C3 DMA Interrupt priority
 // <i> Default: 0
 #define RTE_I2C3_DMA_IRQ_PRI 0
+
+// <o> I2C3 DMA scratch buffer size (entries) <32-256:8>
+// <i> Per-instance 16-bit DMA scratch buffer; sized in DATA_CMD entries.
+// <i> Caps the per-chunk DMA transfer (max 256).
+// <i> Default: 256
+#define RTE_I2C3_DMA_SCRATCH_SIZE 256
 #endif
 
 #endif

--- a/Device/soc/AE822FA0E5597/rte/RTE_Device.h
+++ b/Device/soc/AE822FA0E5597/rte/RTE_Device.h
@@ -9112,6 +9112,12 @@
 // <i> Defines I2C0 DMA Interrupt priority
 // <i> Default: 0
 #define RTE_I2C0_DMA_IRQ_PRI 0
+
+// <o> I2C0 DMA scratch buffer size (entries) <32-256:8>
+// <i> Per-instance 16-bit DMA scratch buffer; sized in DATA_CMD entries.
+// <i> Caps the per-chunk DMA transfer (max 256).
+// <i> Default: 256
+#define RTE_I2C0_DMA_SCRATCH_SIZE 256
 #endif
 
 #endif
@@ -9149,6 +9155,12 @@
 // <i> Defines I2C1 DMA Interrupt priority
 // <i> Default: 0
 #define RTE_I2C1_DMA_IRQ_PRI 0
+
+// <o> I2C1 DMA scratch buffer size (entries) <32-256:8>
+// <i> Per-instance 16-bit DMA scratch buffer; sized in DATA_CMD entries.
+// <i> Caps the per-chunk DMA transfer (max 256).
+// <i> Default: 256
+#define RTE_I2C1_DMA_SCRATCH_SIZE 256
 #endif
 
 #endif
@@ -9186,6 +9198,12 @@
 // <i> Defines I2C2 DMA Interrupt priority
 // <i> Default: 0
 #define RTE_I2C2_DMA_IRQ_PRI 0
+
+// <o> I2C2 DMA scratch buffer size (entries) <32-256:8>
+// <i> Per-instance 16-bit DMA scratch buffer; sized in DATA_CMD entries.
+// <i> Caps the per-chunk DMA transfer (max 256).
+// <i> Default: 256
+#define RTE_I2C2_DMA_SCRATCH_SIZE 256
 #endif
 
 #endif
@@ -9224,6 +9242,12 @@
 // <i> Defines I2C3 DMA Interrupt priority
 // <i> Default: 0
 #define RTE_I2C3_DMA_IRQ_PRI 0
+
+// <o> I2C3 DMA scratch buffer size (entries) <32-256:8>
+// <i> Per-instance 16-bit DMA scratch buffer; sized in DATA_CMD entries.
+// <i> Caps the per-chunk DMA transfer (max 256).
+// <i> Default: 256
+#define RTE_I2C3_DMA_SCRATCH_SIZE 256
 #endif
 
 #endif
@@ -9281,6 +9305,12 @@
 // <i> Defines LPI2C1 DMA Interrupt priority
 // <i> Default: 0
 #define RTE_LPI2C1_DMA_IRQ_PRI 0
+
+// <o> LPI2C1 DMA scratch buffer size (entries) <32-256:8>
+// <i> Per-instance 16-bit DMA scratch buffer; sized in DATA_CMD entries.
+// <i> Caps the per-chunk DMA transfer (max 256).
+// <i> Default: 256
+#define RTE_LPI2C1_DMA_SCRATCH_SIZE 256
 #endif
 
 #endif

--- a/drivers/include/i2c.h
+++ b/drivers/include/i2c.h
@@ -104,13 +104,14 @@ extern "C" {
      I2C_IC_INTR_STAT_RX_UNDER | I2C_IC_INTR_STAT_TX_ABRT | I2C_IC_INTR_STAT_STOP_DET)
 
 #define I2C_IC_INT_DMA_MST_RX_ENABLE                                                               \
-    (I2C_IC_INTR_STAT_TX_EMPTY | I2C_IC_INTR_STAT_RX_OVER | I2C_IC_INTR_STAT_RX_UNDER |            \
+    (I2C_IC_INTR_STAT_RX_OVER | I2C_IC_INTR_STAT_RX_UNDER |                                        \
      I2C_IC_INTR_STAT_TX_ABRT | I2C_IC_INTR_STAT_STOP_DET)
 /* Interrupt enable mask as slave */
 #define I2C_IC_INT_SLV_TX_ENABLE                                                                   \
     (I2C_IC_INTR_STAT_RD_REQ | I2C_IC_INTR_STAT_TX_ABRT | I2C_IC_INTR_STAT_STOP_DET)
 
-#define I2C_IC_INT_DMA_SLV_TX_ENABLE (I2C_IC_INTR_STAT_TX_ABRT | I2C_IC_INTR_STAT_STOP_DET)
+#define I2C_IC_INT_DMA_SLV_TX_ENABLE                                                               \
+    (I2C_IC_INTR_STAT_RD_REQ | I2C_IC_INTR_STAT_TX_ABRT | I2C_IC_INTR_STAT_STOP_DET)
 
 #define I2C_IC_INT_SLV_RX_ENABLE                                                                   \
     (I2C_IC_INTR_STAT_RX_FULL | I2C_IC_INTR_STAT_RX_OVER | I2C_IC_INTR_STAT_RX_UNDER |             \
@@ -624,11 +625,22 @@ static inline void i2c_disable_rx_dma(I2C_Type *i2c)
  * @brief   Returns I2C Rx DMA enable status
  * @note    none
  * @param   i2c    : Pointer to i2c register map
- * @retval  None
+ * @retval  true if RX DMA is enabled, false otherwise
  */
 static inline bool i2c_is_rx_dma_enable(I2C_Type *i2c)
 {
     return ((i2c->I2C_DMA_CR & I2C_DMACR_RX_DMA_ENABLE) != 0);
+}
+
+/**
+ * @brief   Returns I2C Tx DMA enable status
+ * @note    none
+ * @param   i2c    : Pointer to i2c register map
+ * @retval  true if TX DMA is enabled, false otherwise
+ */
+static inline bool i2c_is_tx_dma_enable(I2C_Type *i2c)
+{
+    return ((i2c->I2C_DMA_CR & I2C_DMACR_TX_DMA_ENABLE) != 0);
 }
 
 /**

--- a/drivers/include/i2c.h
+++ b/drivers/include/i2c.h
@@ -46,6 +46,7 @@ extern "C" {
 #define I2C_IC_STATUS_RFF                    (0x10) /* (1 << 4) */
 #define I2C_IC_STATUS_MASTER_ACT             (0x20) /* (1 << 5) */
 #define I2C_IC_STATUS_SLAVE_ACT              (0x40) /* (1 << 6) */
+#define I2C_IC_STATUS_SDA_STUCK_NOT_RECOVERED (1 << 11)
 
 /* Perform a Restart/Stop request */
 #define I2C_IC_DATA_CMD_RESTART              (1 << 10)

--- a/drivers/include/i2c.h
+++ b/drivers/include/i2c.h
@@ -31,9 +31,12 @@ extern "C" {
 /* Disable I2C */
 #define I2C_IC_ENABLE_I2C_DISABLE            (0)
 
+/* Field of IC_ENABLE register */
+#define I2C_IC_ENABLE_ABORT                  (1 << 1)
+#define I2C_IC_SDA_STUCK_RECOVERY_ENABLE     (1 << 3)
+
 /* Field of IC_ENABLE_STATUS register*/
 #define I2C_ENABLE_STATUS_IC_EN              (1 << 0)
-#define I2C_IC_SDA_STUCK_RECOVERY_ENABLE     (1 << 3)
 
 /* i2c Status Register Fields. */
 #define I2C_IC_STATUS_ACTIVITY               (0x01) /* (1 << 0) */
@@ -338,6 +341,17 @@ static inline void i2c_disable(I2C_Type *i2c)
 static inline void i2c_master_recover_sda(I2C_Type *i2c)
 {
     i2c->I2C_ENABLE |= I2C_IC_SDA_STUCK_RECOVERY_ENABLE;
+}
+
+/**
+ * @brief   Initiate transfer abort (sends STOP on bus)
+ * @note    Generates TX_ABRT with USER_ABRT source
+ * @param   i2c : Pointer to i2c register map
+ * @retval  none
+ */
+static inline void i2c_master_abort(I2C_Type *i2c)
+{
+    i2c->I2C_ENABLE |= I2C_IC_ENABLE_ABORT;
 }
 
 /**

--- a/drivers/include/i2c.h
+++ b/drivers/include/i2c.h
@@ -704,6 +704,40 @@ static inline void i2c_enable_dma_slave_rx(I2C_Type *i2c)
 }
 
 /**
+ * @brief   Check whether the TX FIFO is completely empty.
+ * @note    Reads IC_STATUS.TFE.
+ * @param   i2c    : Pointer to i2c register map
+ * @retval  true   if the TX FIFO is empty, false otherwise
+ */
+static inline bool i2c_tx_fifo_empty(I2C_Type *i2c)
+{
+    return ((i2c->I2C_STATUS & I2C_IC_STATUS_TFE) != 0U);
+}
+
+/**
+ * @brief   Read the current TX FIFO occupancy.
+ * @note    Reads IC_TXFLR.
+ * @param   i2c    : Pointer to i2c register map
+ * @retval  Number of valid entries currently in the TX FIFO (0..FIFO_DEPTH)
+ */
+static inline uint32_t i2c_tx_fifo_level(I2C_Type *i2c)
+{
+    return i2c->I2C_TXFLR;
+}
+
+/**
+ * @brief   Check whether a TX_ABRT has latched in the raw interrupt status.
+ * @note    Reads IC_RAW_INTR_STAT.TX_ABRT, which latches independently of
+ *          the IRQ mask
+ * @param   i2c    : Pointer to i2c register map
+ * @retval  true   if TX_ABRT is latched, false otherwise
+ */
+static inline bool i2c_tx_abort_pending(I2C_Type *i2c)
+{
+    return ((i2c->I2C_RAW_INTR_STAT & I2C_IC_INTR_STAT_TX_ABRT) != 0U);
+}
+
+/**
  * @brief    set i2c target address for slave device in master mode
  * @param    i2c       : Pointer to i2c resources structure
  * @param    address   : i2c 7-bit or 10-bit slave address

--- a/drivers/source/i2c.c
+++ b/drivers/source/i2c.c
@@ -9,6 +9,7 @@
  */
 
 #include "i2c.h"
+#include "sys_utils.h"
 
 /**
  * @brief   Set scl count
@@ -489,10 +490,11 @@ void i2c_master_tx_isr(I2C_Type *i2c, i2c_transfer_info_t *transfer)
 
     i2c_master_check_error(i2c, transfer);
 
-    /* Checks if Tx FIFO is empty then
-     * performs the below operations
+    /* Checks if Tx FIFO is empty then,
+     * Skip when TX DMA is enabled and the I2C controller masks TX_EMPTY
+     * for the DMA path.
      */
-    if ((!transfer->abort) &&
+    if ((!transfer->abort) && (!i2c_is_tx_dma_enable(i2c)) &&
         (i2c_int_status & I2C_IC_INTR_STAT_TX_EMPTY)) {
         do {
             xmit_data = (uint16_t) (transfer->tx_buf[transfer->tx_curr_cnt++]) |
@@ -557,6 +559,9 @@ void i2c_master_tx_isr(I2C_Type *i2c, i2c_transfer_info_t *transfer)
 
         /* transmitted all the bytes, disable the transmit interrupt */
         i2c_master_disable_tx_interrupt(i2c);
+
+        /* Clear TDMAE so the next master transmit can re-arm DMA cleanly. */
+        i2c_disable_tx_dma(i2c);
     }
 }
 
@@ -577,7 +582,8 @@ void i2c_master_rx_isr(I2C_Type *i2c, i2c_transfer_info_t *transfer)
     i2c_master_check_error(i2c, transfer);
 
     if (!transfer->abort) {
-        if (i2c_int_status & I2C_IC_INTR_STAT_TX_EMPTY) {
+        if ((!i2c_is_tx_dma_enable(i2c)) &&
+            (i2c_int_status & I2C_IC_INTR_STAT_TX_EMPTY)) {
 
             if (transfer->wr_mode) {
                 while (i2c_tx_ready(i2c)) {
@@ -614,9 +620,10 @@ void i2c_master_rx_isr(I2C_Type *i2c, i2c_transfer_info_t *transfer)
         /* Checks if transmitted all the read condition,
          *  waiting for i2c to receive data from slave.
          * IC_INTR_STAT_RX_FULL set when i2c receives reaches
-         * or goes above RX_TL threshold
+         * threshold. Skip when RX DMA is enabled
          */
-        if (i2c_int_status & I2C_IC_INTR_STAT_RX_FULL) {
+        if ((!i2c_is_rx_dma_enable(i2c)) &&
+            (i2c_int_status & I2C_IC_INTR_STAT_RX_FULL)) {
             while (i2c_rx_ready(i2c)) {
                 /* rx ready, data is available into data buffer read it. */
                 transfer->rx_buf[transfer->rx_curr_cnt] = i2c_read_data_from_buffer(i2c);
@@ -684,9 +691,14 @@ void i2c_master_rx_isr(I2C_Type *i2c, i2c_transfer_info_t *transfer)
             }
             /* Rx-DMA is enabled, so perform the below */
             else {
-                transfer->curr_stat  = I2C_XFER_NONE;
-                /* mark event as master receive complete successfully. */
-                transfer->evt_sts    |= I2C_XFER_EVENT_DONE;
+                transfer->curr_stat = I2C_XFER_NONE;
+                if (i2c->I2C_RXFLR == 0U) {
+                    /* mark event as master receive complete successfully. */
+                    transfer->evt_sts |= I2C_XFER_EVENT_DONE;
+                } else {
+                    /* DMA did not drain in time — truncated transfer. */
+                    transfer->evt_sts |= I2C_XFER_EVENT_INCOMPLETE;
+                }
             }
         } else {
             /* Promote SDA_STUCK_AT_LOW to BUS_CLEAR only on a user
@@ -711,6 +723,9 @@ void i2c_master_rx_isr(I2C_Type *i2c, i2c_transfer_info_t *transfer)
 
         /* Stop bit detected, disable the Receive interrupt */
         i2c_master_disable_rx_interrupt(i2c);
+
+        /* Clear RDMAE so the next master receive can re-arm DMA cleanly. */
+        i2c_disable_rx_dma(i2c);
     }
 }
 
@@ -732,8 +747,25 @@ void i2c_slave_tx_isr(I2C_Type *i2c, i2c_transfer_info_t *transfer)
 
     /* Slave is Active */
     if (i2c->I2C_STATUS & I2C_IC_STATUS_SLAVE_ACT) {
-        /* Fill data when Read is requested */
-        if ((!transfer->abort) && (i2c_int_status & I2C_IC_INTR_STAT_RD_REQ)) {
+        /* DMA-mode arm-on-RD_REQ. tx_total_num == 0 distinguishes
+         * DMA SlaveTransmit (channels armed by upper layer, byte
+         * count not tracked here) from IRQ SlaveTransmit (which
+         * populates tx_total_num). Enable TDMAE so the DMA channel
+         * pushes the first byte, then mask RD_REQ so a transient
+         * FIFO underrun mid-transaction does not re-enter this
+         * block
+         */
+        if ((!transfer->abort) && (transfer->tx_total_num == 0U) &&
+            (i2c_int_status & I2C_IC_INTR_STAT_RD_REQ) &&
+            (!i2c_is_tx_dma_enable(i2c))) {
+            i2c_enable_tx_dma(i2c);
+            i2c_mask_interrupt(i2c, I2C_IC_INTR_STAT_RD_REQ);
+            (void) i2c->I2C_CLR_RD_REQ;
+        }
+
+        /* Fill data when Read is requested. Skip when TX DMA is enabled. */
+        if ((!transfer->abort) && (!i2c_is_tx_dma_enable(i2c)) &&
+            (i2c_int_status & I2C_IC_INTR_STAT_RD_REQ)) {
             /* checking FIFO is full ready to transmit data */
             while (i2c_tx_ready(i2c)) {
                 xmit_data = (uint16_t) (transfer->tx_buf[transfer->tx_curr_cnt]) |
@@ -766,12 +798,19 @@ void i2c_slave_tx_isr(I2C_Type *i2c, i2c_transfer_info_t *transfer)
     if (i2c_int_status & I2C_IC_INTR_STAT_STOP_DET) {
         (void) i2c->I2C_CLR_STOP_DET;
 
-        transfer->curr_stat  = I2C_XFER_NONE;
-
-        /* mark event as slave transmit complete successfully. */
-        transfer->evt_sts    |= I2C_XFER_EVENT_DONE;
-        /* disable the transmit interrupt */
+        transfer->curr_stat = I2C_XFER_NONE;
         i2c_slave_disable_tx_interrupt(i2c);
+
+        if (i2c_is_tx_dma_enable(i2c)) {
+            /* STOP arrived while DMA still active — master read fewer
+             * bytes than provided. Report incomplete.
+             */
+            i2c_disable_tx_dma(i2c);
+            transfer->evt_sts |= I2C_XFER_EVENT_INCOMPLETE;
+        } else {
+            /* IRQ mode, or DMA already drained cleanly. Report success. */
+            transfer->evt_sts |= I2C_XFER_EVENT_DONE;
+        }
     }
 
     if (transfer->abort) {
@@ -779,6 +818,7 @@ void i2c_slave_tx_isr(I2C_Type *i2c, i2c_transfer_info_t *transfer)
         transfer->curr_stat  = I2C_XFER_NONE;
         /* disable the transmit interrupt */
         i2c_slave_disable_tx_interrupt(i2c);
+        i2c_disable_tx_dma(i2c);
     }
 }
 
@@ -797,8 +837,9 @@ void i2c_slave_rx_isr(I2C_Type *i2c, i2c_transfer_info_t *transfer)
     /* Slave error state check */
     i2c_slave_check_error(i2c, transfer);
 
-    /* Checking for the RX full interrupt */
-    if (i2c_int_status & I2C_IC_INTR_STAT_RX_FULL) {
+    /* Checking for the RX full interrupt. Skip when RX DMA is enabled. */
+    if ((!i2c_is_rx_dma_enable(i2c)) &&
+        (i2c_int_status & I2C_IC_INTR_STAT_RX_FULL)) {
         /* Ready to receive data, FIFO has data */
         while (i2c_rx_ready(i2c)) {
             /* rx ready, data is available into data buffer read it. */
@@ -825,29 +866,40 @@ void i2c_slave_rx_isr(I2C_Type *i2c, i2c_transfer_info_t *transfer)
     if (i2c_int_status & I2C_IC_INTR_STAT_STOP_DET) {
         (void) i2c->I2C_CLR_STOP_DET;
 
-        if (transfer->rx_curr_cnt < transfer->rx_total_num) {
-            /* Checks if there are pending data
-             * present in Rx FIFO that are expected
-             */
-            if (i2c->I2C_RXFLR >= (transfer->rx_total_num - (transfer->rx_curr_cnt + 1U))) {
-                while (transfer->rx_total_num - transfer->rx_curr_cnt) {
-                    /* Read the data available in data buffer. */
-                    transfer->rx_buf[transfer->rx_curr_cnt] = i2c_read_data_from_buffer(i2c);
+        if (!i2c_is_rx_dma_enable(i2c)) {
+            if (transfer->rx_curr_cnt < transfer->rx_total_num) {
+                /* Checks if there are pending data
+                 * present in Rx FIFO that are expected
+                 */
+                if (i2c->I2C_RXFLR >= (transfer->rx_total_num - (transfer->rx_curr_cnt + 1U))) {
+                    while (transfer->rx_total_num - transfer->rx_curr_cnt) {
+                        /* Read the data available in data buffer. */
+                        transfer->rx_buf[transfer->rx_curr_cnt] = i2c_read_data_from_buffer(i2c);
 
-                    transfer->rx_curr_cnt++;
-                    transfer->curr_cnt = transfer->rx_curr_cnt;
+                        transfer->rx_curr_cnt++;
+                        transfer->curr_cnt = transfer->rx_curr_cnt;
+                    }
                 }
             }
+            /* Checks if expected number of bytes received */
+            if (transfer->rx_curr_cnt >= transfer->rx_total_num) {
+                transfer->curr_stat  = I2C_XFER_NONE;
+                /* mark event as Slave Receive complete successfully. */
+                transfer->evt_sts    |= I2C_XFER_EVENT_DONE;
+            } else {
+                transfer->curr_stat  = I2C_XFER_NONE;
+                /* mark event as Slave Receive incomplete. */
+                transfer->evt_sts    |= I2C_XFER_EVENT_INCOMPLETE;
+            }
         }
-        /* Checks mode is DMA or if expected number of bytes received*/
-        if (transfer->rx_curr_cnt >= transfer->rx_total_num) {
-            transfer->curr_stat  = I2C_XFER_NONE;
-            /* mark event as Slave Receive complete successfully. */
-            transfer->evt_sts    |= I2C_XFER_EVENT_DONE;
-        } else {
-            transfer->curr_stat  = I2C_XFER_NONE;
-            /* mark event as Slave Receive incomplete. */
-            transfer->evt_sts    |= I2C_XFER_EVENT_INCOMPLETE;
+        /* Rx-DMA is enabled */
+        else {
+            /* DMA with Abort cases: Make sure no inflight transfer */
+            sys_busy_loop_us(1);
+
+            transfer->curr_stat = I2C_XFER_NONE;
+            transfer->evt_sts |= I2C_XFER_EVENT_INCOMPLETE;
+            i2c_disable_rx_dma(i2c);
         }
         /* Disable the RX interrupt */
         i2c_slave_disable_rx_interrupt(i2c);

--- a/drivers/source/i2c.c
+++ b/drivers/source/i2c.c
@@ -245,7 +245,11 @@ static void i2c_master_check_error(I2C_Type *i2c, i2c_transfer_info_t *transfer)
     if (status & I2C_IC_INTR_STAT_TX_ABRT) {
         status = i2c->I2C_TX_ABRT_SOURCE;
 
-        if (status & I2C_ABRT_ARBITRATION_LOST) {
+        /* Check USER_ABRT first - it's a deliberate user action */
+        if (status & I2C_IC_TX_ABRT_USER_ABRT) {
+            /* User aborted the xfer */
+            transfer->evt_sts = I2C_XFER_EVENT_USER_ABORT;
+        } else if (status & I2C_ABRT_ARBITRATION_LOST) {
             /* Master lost arbitration. */
             transfer->evt_sts = I2C_XFER_EVENT_ARBITRATION_LOST;
         } else if (status & I2C_MST_ABRT_ADDR_NOACK) {
@@ -270,9 +274,6 @@ static void i2c_master_check_error(I2C_Type *i2c, i2c_transfer_info_t *transfer)
         } else if (status & I2C_IC_TX_ABRT_MASTER_DIS) {
             /* Master mode disabled */
             transfer->evt_sts = I2C_XFER_EVENT_MASTER_DIS;
-        } else if (status & I2C_IC_TX_ABRT_USER_ABRT) {
-            /* User aborted the xfer */
-            transfer->evt_sts = I2C_XFER_EVENT_USER_ABORT;
         } else if (status & I2C_IC_TX_ABRT_SDA_STUCK_AT_LOW) {
             /* SDA line stuck at low  */
             transfer->evt_sts = I2C_XFER_EVENT_SDA_STUCK_AT_LOW;

--- a/drivers/source/i2c.c
+++ b/drivers/source/i2c.c
@@ -307,10 +307,6 @@ static void i2c_slave_check_error(I2C_Type *i2c, i2c_transfer_info_t *transfer)
         (void)i2c->I2C_CLR_START_DET;
     }
 
-    if (status & I2C_IC_INTR_STAT_STOP_DET) {
-        (void)i2c->I2C_CLR_STOP_DET;
-    }
-
     if (status & I2C_IC_INTR_STAT_GEN_CALL) {
         (void)i2c->I2C_CLR_GEN_CALL;
     }
@@ -492,9 +488,6 @@ void i2c_master_tx_isr(I2C_Type *i2c, i2c_transfer_info_t *transfer)
 
     i2c_master_check_error(i2c, transfer);
 
-    /* Clear Interrupt */
-    (void) i2c->I2C_CLR_INTR;
-
     /* Checks if Tx FIFO is empty then
      * performs the below operations
      */
@@ -534,6 +527,8 @@ void i2c_master_tx_isr(I2C_Type *i2c, i2c_transfer_info_t *transfer)
     }
 
     if (i2c_int_status & I2C_IC_INTR_STAT_STOP_DET) {
+        (void) i2c->I2C_CLR_STOP_DET;
+
         transfer->curr_stat = I2C_XFER_NONE;
         if (!transfer->abort) {
             /* mark event as master receive complete successfully. */
@@ -567,9 +562,6 @@ void i2c_master_rx_isr(I2C_Type *i2c, i2c_transfer_info_t *transfer)
     i2c_int_status        = (i2c->I2C_INTR_STAT);
 
     i2c_master_check_error(i2c, transfer);
-
-    /* Clear Interrupt */
-    (void) i2c->I2C_CLR_INTR;
 
     if (!transfer->abort) {
         if (i2c_int_status & I2C_IC_INTR_STAT_TX_EMPTY) {
@@ -641,6 +633,8 @@ void i2c_master_rx_isr(I2C_Type *i2c, i2c_transfer_info_t *transfer)
     }
 
     if (i2c_int_status & I2C_IC_INTR_STAT_STOP_DET) {
+        (void) i2c->I2C_CLR_STOP_DET;
+
         if (!transfer->abort) {
             /* Checks if rx-dma is not enabled */
             if (!i2c_is_rx_dma_enable(i2c)) {
@@ -711,9 +705,6 @@ void i2c_slave_tx_isr(I2C_Type *i2c, i2c_transfer_info_t *transfer)
     /* Slave error state check */
     i2c_slave_check_error(i2c, transfer);
 
-    /* Clear Interrupt */
-    (void) i2c->I2C_CLR_INTR;
-
     /* Slave is Active */
     if (i2c->I2C_STATUS & I2C_IC_STATUS_SLAVE_ACT) {
         /* Fill data when Read is requested */
@@ -741,11 +732,15 @@ void i2c_slave_tx_isr(I2C_Type *i2c, i2c_transfer_info_t *transfer)
                 } /* (xmit_end) */
 
             } /* while(i2c_tx_ready(i2c_reg_ptr)) END*/
+
+            (void) i2c->I2C_CLR_RD_REQ;
         } /* Read request END */
     } /* (i2c_reg_ptr->ic_status & I2C_IC_STATUS_SLAVE_ACT) END*/
 
     /* Checks for stop condition */
     if (i2c_int_status & I2C_IC_INTR_STAT_STOP_DET) {
+        (void) i2c->I2C_CLR_STOP_DET;
+
         transfer->curr_stat  = I2C_XFER_NONE;
 
         /* mark event as slave transmit complete successfully. */
@@ -774,8 +769,8 @@ void i2c_slave_rx_isr(I2C_Type *i2c, i2c_transfer_info_t *transfer)
 
     i2c_int_status = (i2c->I2C_INTR_STAT);
 
-    /* Clear Interrupt */
-    (void) i2c->I2C_CLR_INTR;
+    /* Slave error state check */
+    i2c_slave_check_error(i2c, transfer);
 
     /* Checking for the RX full interrupt */
     if (i2c_int_status & I2C_IC_INTR_STAT_RX_FULL) {
@@ -803,6 +798,8 @@ void i2c_slave_rx_isr(I2C_Type *i2c, i2c_transfer_info_t *transfer)
     } /* (i2c_int_status & I2C_IC_INTR_STAT_RX_FULL) END */
 
     if (i2c_int_status & I2C_IC_INTR_STAT_STOP_DET) {
+        (void) i2c->I2C_CLR_STOP_DET;
+
         if (transfer->rx_curr_cnt < transfer->rx_total_num) {
             /* Checks if there are pending data
              * present in Rx FIFO that are expected

--- a/drivers/source/i2c.c
+++ b/drivers/source/i2c.c
@@ -535,13 +535,25 @@ void i2c_master_tx_isr(I2C_Type *i2c, i2c_transfer_info_t *transfer)
             /* mark event as master receive complete successfully. */
             transfer->evt_sts    |= I2C_XFER_EVENT_DONE;
         } else {
-            /* mark event as bus cleared successfully. */
-            if (transfer->cmd_bus_clr) {
-                transfer->evt_sts |= I2C_XFER_EVENT_BUS_CLEAR;
+            /* Promote SDA_STUCK_AT_LOW to BUS_CLEAR only on a user
+             * bus-clear that actually recovered.
+             */
+            if (transfer->cmd_bus_clr &&
+                (transfer->evt_sts & I2C_XFER_EVENT_SDA_STUCK_AT_LOW)) {
+                if (!(i2c->I2C_STATUS & I2C_IC_STATUS_SDA_STUCK_NOT_RECOVERED)) {
+                    transfer->evt_sts = (transfer->evt_sts &
+                                         ~I2C_XFER_EVENT_SDA_STUCK_AT_LOW) |
+                                        I2C_XFER_EVENT_BUS_CLEAR;
+                }
             }
             /* clear xfer abort status */
             transfer->abort = false;
         }
+        /* cmd_bus_clr is scoped to one BUS_CLEAR command; the HW ends
+         * that command with STOP_DET whether recovery succeeded or not.
+         * Clear here so the flag never leaks into the next transfer.
+         */
+        transfer->cmd_bus_clr = false;
 
         /* transmitted all the bytes, disable the transmit interrupt */
         i2c_master_disable_tx_interrupt(i2c);
@@ -677,13 +689,25 @@ void i2c_master_rx_isr(I2C_Type *i2c, i2c_transfer_info_t *transfer)
                 transfer->evt_sts    |= I2C_XFER_EVENT_DONE;
             }
         } else {
-            /* mark event as bus cleared successfully. */
-            if (transfer->cmd_bus_clr) {
-                transfer->evt_sts |= I2C_XFER_EVENT_BUS_CLEAR;
+            /* Promote SDA_STUCK_AT_LOW to BUS_CLEAR only on a user
+             * bus-clear that actually recovered.
+             */
+            if (transfer->cmd_bus_clr &&
+                (transfer->evt_sts & I2C_XFER_EVENT_SDA_STUCK_AT_LOW)) {
+                if (!(i2c->I2C_STATUS & I2C_IC_STATUS_SDA_STUCK_NOT_RECOVERED)) {
+                    transfer->evt_sts = (transfer->evt_sts &
+                                         ~I2C_XFER_EVENT_SDA_STUCK_AT_LOW) |
+                                        I2C_XFER_EVENT_BUS_CLEAR;
+                }
             }
             /* clear xfer abort status */
             transfer->abort = false;
         }
+        /* cmd_bus_clr is scoped to one BUS_CLEAR command; the HW ends
+         * that command with STOP_DET whether recovery succeeded or not.
+         * Clear here so the flag never leaks into the next transfer.
+         */
+        transfer->cmd_bus_clr = false;
 
         /* Stop bit detected, disable the Receive interrupt */
         i2c_master_disable_rx_interrupt(i2c);


### PR DESCRIPTION
Fix the application 16bit buffer constraint for the DMA transfers by implementing the custom microcode