### PR TITLE
Boards: board_defs.h: rename PDM pin macros to generic names

### DIFF
--- a/Boards/AppKit-e7-aiml/board_defs.h
+++ b/Boards/AppKit-e7-aiml/board_defs.h
@@ -831,66 +831,82 @@
 // <o> "PDM_D0_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_D0_A_GPIO_PORT                        0
+#define BOARD_PDM_D0_GPIO_PORT                          0
 // <o> "PDM_D0_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_D0_A_GPIO_PIN                         4
+#define BOARD_PDM_D0_GPIO_PIN                           4
+// <o> "PDM_D0_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_D0_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_D1_C" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_D1_C_GPIO_PORT                        6
+#define BOARD_PDM_D1_GPIO_PORT                          6
 // <o> "PDM_D1_C" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_D1_C_GPIO_PIN                         2
+#define BOARD_PDM_D1_GPIO_PIN                           2
+// <o> "PDM_D1_C" GPIO pin alternate function <0-7>
+#define BOARD_PDM_D1_ALTERNATE_FUNCTION                 4
 
 // <o> "PDM_D2_B" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_D2_B_GPIO_PORT                        5
+#define BOARD_PDM_D2_GPIO_PORT                          5
 // <o> "PDM_D2_B" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_D2_B_GPIO_PIN                         4
+#define BOARD_PDM_D2_GPIO_PIN                           4
+// <o> "PDM_D2_B" GPIO pin alternate function <0-7>
+#define BOARD_PDM_D2_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_D3_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_D3_A_GPIO_PORT                        5
+#define BOARD_PDM_D3_GPIO_PORT                          5
 // <o> "PDM_D3_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_D3_A_GPIO_PIN                         1
+#define BOARD_PDM_D3_GPIO_PIN                           1
+// <o> "PDM_D3_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_D3_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_C0_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_C0_A_GPIO_PORT                        0
+#define BOARD_PDM_C0_GPIO_PORT                          0
 // <o> "PDM_C0_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_C0_A_GPIO_PIN                         5
+#define BOARD_PDM_C0_GPIO_PIN                           5
+// <o> "PDM_C0_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_C0_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_C1_C" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_C1_C_GPIO_PORT                        6
+#define BOARD_PDM_C1_GPIO_PORT                          6
 // <o> "PDM_C1_C" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_C1_C_GPIO_PIN                         3
+#define BOARD_PDM_C1_GPIO_PIN                           3
+// <o> "PDM_C1_C" GPIO pin alternate function <0-7>
+#define BOARD_PDM_C1_ALTERNATE_FUNCTION                 4
 
 // <o> "PDM_C2_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_C2_A_GPIO_PORT                        6
+#define BOARD_PDM_C2_GPIO_PORT                          6
 // <o> "PDM_C2_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_C2_A_GPIO_PIN                         7
+#define BOARD_PDM_C2_GPIO_PIN                           7
+// <o> "PDM_C2_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_C2_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_C3_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_C3_A_GPIO_PORT                        5
+#define BOARD_PDM_C3_GPIO_PORT                          5
 // <o> "PDM_C3_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_C3_A_GPIO_PIN                         2
+#define BOARD_PDM_C3_GPIO_PIN                           2
+// <o> "PDM_C3_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_C3_ALTERNATE_FUNCTION                 3
 
 // <o> "TOUCH_RESET" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=>
 // GPIO5 <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=>

--- a/Boards/AppKit-e8/board_defs.h
+++ b/Boards/AppKit-e8/board_defs.h
@@ -488,66 +488,82 @@
 // <o> "PDM_D0_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_D0_A_GPIO_PORT                        3
+#define BOARD_PDM_D0_GPIO_PORT                          3
 // <o> "PDM_D0_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_D0_A_GPIO_PIN                         4
+#define BOARD_PDM_D0_GPIO_PIN                           4
+// <o> "PDM_D0_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_D0_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_D1_C" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_D1_C_GPIO_PORT                        6
+#define BOARD_PDM_D1_GPIO_PORT                          6
 // <o> "PDM_D1_C" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_D1_C_GPIO_PIN                         2
+#define BOARD_PDM_D1_GPIO_PIN                           2
+// <o> "PDM_D1_C" GPIO pin alternate function <0-7>
+#define BOARD_PDM_D1_ALTERNATE_FUNCTION                 4
 
 // <o> "PDM_D2_B" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_D2_B_GPIO_PORT                        5
+#define BOARD_PDM_D2_GPIO_PORT                          5
 // <o> "PDM_D2_B" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_D2_B_GPIO_PIN                         4
+#define BOARD_PDM_D2_GPIO_PIN                           4
+// <o> "PDM_D2_B" GPIO pin alternate function <0-7>
+#define BOARD_PDM_D2_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_D3_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_D3_A_GPIO_PORT                        5
+#define BOARD_PDM_D3_GPIO_PORT                          5
 // <o> "PDM_D3_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_D3_A_GPIO_PIN                         1
+#define BOARD_PDM_D3_GPIO_PIN                           1
+// <o> "PDM_D3_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_D3_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_C0_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_C0_A_GPIO_PORT                        3
+#define BOARD_PDM_C0_GPIO_PORT                          3
 // <o> "PDM_C0_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_C0_A_GPIO_PIN                         5
+#define BOARD_PDM_C0_GPIO_PIN                           5
+// <o> "PDM_C0_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_C0_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_C1_C" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_C1_C_GPIO_PORT                        6
+#define BOARD_PDM_C1_GPIO_PORT                          6
 // <o> "PDM_C1_C" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_C1_C_GPIO_PIN                         3
+#define BOARD_PDM_C1_GPIO_PIN                           3
+// <o> "PDM_C1_C" GPIO pin alternate function <0-7>
+#define BOARD_PDM_C1_ALTERNATE_FUNCTION                 4
 
 // <o> "PDM_C2_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_C2_A_GPIO_PORT                        6
+#define BOARD_PDM_C2_GPIO_PORT                          6
 // <o> "PDM_C2_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_C2_A_GPIO_PIN                         7
+#define BOARD_PDM_C2_GPIO_PIN                           7
+// <o> "PDM_C2_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_C2_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_C3_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_C3_A_GPIO_PORT                        5
+#define BOARD_PDM_C3_GPIO_PORT                          5
 // <o> "PDM_C3_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_C3_A_GPIO_PIN                         2
+#define BOARD_PDM_C3_GPIO_PIN                           2
+// <o> "PDM_C3_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_C3_ALTERNATE_FUNCTION                 3
 
 // <o> "TOUCH_RESET" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=>
 // GPIO5 <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=>

--- a/Boards/DevKit-e1c/board_defs.h
+++ b/Boards/DevKit-e1c/board_defs.h
@@ -695,59 +695,75 @@
 
 // <o> "PDM_D0_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <15=> LPGPIO
-#define BOARD_PDM_D0_A_GPIO_PORT                        0
+#define BOARD_PDM_D0_GPIO_PORT                          0
 // <o> "PDM_D0_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_D0_A_GPIO_PIN                         4
+#define BOARD_PDM_D0_GPIO_PIN                           4
+// <o> "PDM_D0_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_D0_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_D1_C" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <15=> LPGPIO
-#define BOARD_PDM_D1_C_GPIO_PORT                        6
+#define BOARD_PDM_D1_GPIO_PORT                          6
 // <o> "PDM_D1_C" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_D1_C_GPIO_PIN                         2
+#define BOARD_PDM_D1_GPIO_PIN                           2
+// <o> "PDM_D1_C" GPIO pin alternate function <0-7>
+#define BOARD_PDM_D1_ALTERNATE_FUNCTION                 4
 
 // <o> "PDM_D2_B" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <15=> LPGPIO
-#define BOARD_PDM_D2_B_GPIO_PORT                        5
+#define BOARD_PDM_D2_GPIO_PORT                          5
 // <o> "PDM_D2_B" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_D2_B_GPIO_PIN                         4
+#define BOARD_PDM_D2_GPIO_PIN                           4
+// <o> "PDM_D2_B" GPIO pin alternate function <0-7>
+#define BOARD_PDM_D2_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_D3_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <15=> LPGPIO
-#define BOARD_PDM_D3_A_GPIO_PORT                        5
+#define BOARD_PDM_D3_GPIO_PORT                          5
 // <o> "PDM_D3_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_D3_A_GPIO_PIN                         1
+#define BOARD_PDM_D3_GPIO_PIN                           1
+// <o> "PDM_D3_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_D3_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_C0_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <15=> LPGPIO
-#define BOARD_PDM_C0_A_GPIO_PORT                        0
+#define BOARD_PDM_C0_GPIO_PORT                          0
 // <o> "PDM_C0_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_C0_A_GPIO_PIN                         5
+#define BOARD_PDM_C0_GPIO_PIN                           5
+// <o> "PDM_C0_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_C0_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_C1_C" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <15=> LPGPIO
-#define BOARD_PDM_C1_C_GPIO_PORT                        6
+#define BOARD_PDM_C1_GPIO_PORT                          6
 // <o> "PDM_C1_C" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_C1_C_GPIO_PIN                         3
+#define BOARD_PDM_C1_GPIO_PIN                           3
+// <o> "PDM_C1_C" GPIO pin alternate function <0-7>
+#define BOARD_PDM_C1_ALTERNATE_FUNCTION                 4
 
 // <o> "PDM_C2_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <15=> LPGPIO
-#define BOARD_PDM_C2_A_GPIO_PORT                        6
+#define BOARD_PDM_C2_GPIO_PORT                          6
 // <o> "PDM_C2_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_C2_A_GPIO_PIN                         7
+#define BOARD_PDM_C2_GPIO_PIN                           7
+// <o> "PDM_C2_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_C2_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_C3_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <15=> LPGPIO
-#define BOARD_PDM_C3_A_GPIO_PORT                        5
+#define BOARD_PDM_C3_GPIO_PORT                          5
 // <o> "PDM_C3_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_C3_A_GPIO_PIN                         2
+#define BOARD_PDM_C3_GPIO_PIN                           2
+// <o> "PDM_C3_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_D3_ALTERNATE_FUNCTION                 3
 
 // <o> "TOUCH_RESET" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=>
 // GPIO5 <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <15=> LPGPIO

--- a/Boards/DevKit-e4/board_defs.h
+++ b/Boards/DevKit-e4/board_defs.h
@@ -845,66 +845,82 @@
 // <o> "PDM_D0_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_D0_A_GPIO_PORT                        0
+#define BOARD_PDM_D0_GPIO_PORT                          0
 // <o> "PDM_D0_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_D0_A_GPIO_PIN                         4
+#define BOARD_PDM_D0_GPIO_PIN                           4
+// <o> "PDM_D0_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_D0_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_D1_C" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_D1_C_GPIO_PORT                        6
+#define BOARD_PDM_D1_GPIO_PORT                          6
 // <o> "PDM_D1_C" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_D1_C_GPIO_PIN                         2
+#define BOARD_PDM_D1_GPIO_PIN                           2
+// <o> "PDM_D1_C" GPIO pin alternate function <0-7>
+#define BOARD_PDM_D1_ALTERNATE_FUNCTION                 4
 
 // <o> "PDM_D2_B" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_D2_B_GPIO_PORT                        5
+#define BOARD_PDM_D2_GPIO_PORT                          5
 // <o> "PDM_D2_B" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_D2_B_GPIO_PIN                         4
+#define BOARD_PDM_D2_GPIO_PIN                           4
+// <o> "PDM_D2_B" GPIO pin alternate function <0-7>
+#define BOARD_PDM_D2_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_D3_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_D3_A_GPIO_PORT                        5
+#define BOARD_PDM_D3_GPIO_PORT                          5
 // <o> "PDM_D3_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_D3_A_GPIO_PIN                         1
+#define BOARD_PDM_D3_GPIO_PIN                           1
+// <o> "PDM_D3_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_D3_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_C0_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_C0_A_GPIO_PORT                        0
+#define BOARD_PDM_C0_GPIO_PORT                          0
 // <o> "PDM_C0_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_C0_A_GPIO_PIN                         5
+#define BOARD_PDM_C0_GPIO_PIN                           5
+// <o> "PDM_C0_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_C0_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_C1_C" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_C1_C_GPIO_PORT                        6
+#define BOARD_PDM_C1_GPIO_PORT                          6
 // <o> "PDM_C1_C" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_C1_C_GPIO_PIN                         3
+#define BOARD_PDM_C1_GPIO_PIN                           3
+// <o> "PDM_C1_C" GPIO pin alternate function <0-7>
+#define BOARD_PDM_C1_ALTERNATE_FUNCTION                 4
 
 // <o> "PDM_C2_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_C2_A_GPIO_PORT                        6
+#define BOARD_PDM_C2_GPIO_PORT                          6
 // <o> "PDM_C2_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_C2_A_GPIO_PIN                         7
+#define BOARD_PDM_C2_GPIO_PIN                           7
+// <o> "PDM_C2_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_C2_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_C3_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_C3_A_GPIO_PORT                        5
+#define BOARD_PDM_C3_GPIO_PORT                          5
 // <o> "PDM_C3_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_C3_A_GPIO_PIN                         2
+#define BOARD_PDM_C3_GPIO_PIN                           2
+// <o> "PDM_C0_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_C3_ALTERNATE_FUNCTION                 3
 
 // <o> "TOUCH_RESET" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=>
 // GPIO5 <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=>

--- a/Boards/DevKit-e7/board_defs.h
+++ b/Boards/DevKit-e7/board_defs.h
@@ -831,66 +831,82 @@
 // <o> "PDM_D0_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_D0_A_GPIO_PORT                        0
+#define BOARD_PDM_D0_GPIO_PORT                          0
 // <o> "PDM_D0_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_D0_A_GPIO_PIN                         4
+#define BOARD_PDM_D0_GPIO_PIN                           4
+// <o> "PDM_D0_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_D0_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_D1_C" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_D1_C_GPIO_PORT                        6
+#define BOARD_PDM_D1_GPIO_PORT                          6
 // <o> "PDM_D1_C" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_D1_C_GPIO_PIN                         2
+#define BOARD_PDM_D1_GPIO_PIN                           2
+// <o> "PDM_D1_C" GPIO pin alternate function <0-7>
+#define BOARD_PDM_D1_ALTERNATE_FUNCTION                 4
 
 // <o> "PDM_D2_B" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_D2_B_GPIO_PORT                        5
+#define BOARD_PDM_D2_GPIO_PORT                          5
 // <o> "PDM_D2_B" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_D2_B_GPIO_PIN                         4
+#define BOARD_PDM_D2_GPIO_PIN                           4
+// <o> "PDM_D2_B" GPIO pin alternate function <0-7>
+#define BOARD_PDM_D2_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_D3_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_D3_A_GPIO_PORT                        5
+#define BOARD_PDM_D3_GPIO_PORT                          5
 // <o> "PDM_D3_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_D3_A_GPIO_PIN                         1
+#define BOARD_PDM_D3_GPIO_PIN                           1
+// <o> "PDM_D3_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_D3_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_C0_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_C0_A_GPIO_PORT                        0
+#define BOARD_PDM_C0_GPIO_PORT                          0
 // <o> "PDM_C0_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_C0_A_GPIO_PIN                         5
+#define BOARD_PDM_C0_GPIO_PIN                           5
+// <o> "PDM_C0_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_C0_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_C1_C" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_C1_C_GPIO_PORT                        6
+#define BOARD_PDM_C1_GPIO_PORT                          6
 // <o> "PDM_C1_C" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_C1_C_GPIO_PIN                         3
+#define BOARD_PDM_C1_GPIO_PIN                           3
+// <o> "PDM_C1_C" GPIO pin alternate function <0-7>
+#define BOARD_PDM_C1_ALTERNATE_FUNCTION                 4
 
 // <o> "PDM_C2_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_C2_A_GPIO_PORT                        6
+#define BOARD_PDM_C2_GPIO_PORT                          6
 // <o> "PDM_C2_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_C2_A_GPIO_PIN                         7
+#define BOARD_PDM_C2_GPIO_PIN                           7
+// <o> "PDM_C2_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_C2_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_C3_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_C3_A_GPIO_PORT                        5
+#define BOARD_PDM_C3_GPIO_PORT                          5
 // <o> "PDM_C3_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_C3_A_GPIO_PIN                         2
+#define BOARD_PDM_C3_GPIO_PIN                           2
+// <o> "PDM_C3_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_C3_ALTERNATE_FUNCTION                 3
 
 // <o> "TOUCH_RESET" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=>
 // GPIO5 <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=>

--- a/Boards/DevKit-e8/board_defs.h
+++ b/Boards/DevKit-e8/board_defs.h
@@ -853,66 +853,82 @@
 // <o> "PDM_D0_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_D0_A_GPIO_PORT                        0
+#define BOARD_PDM_D0_GPIO_PORT                          0
 // <o> "PDM_D0_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_D0_A_GPIO_PIN                         4
+#define BOARD_PDM_D0_GPIO_PIN                           4
+// <o> "PDM_D0_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_D0_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_D1_C" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_D1_C_GPIO_PORT                        6
-// <o> "PDM_D1_C" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
+#define BOARD_PDM_D1_GPIO_PORT                          3
+// <o> "PDM_D1_B" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_D1_C_GPIO_PIN                         2
+#define BOARD_PDM_D1_GPIO_PIN                           2
+// <o> "PDM_D1_B" GPIO pin alternate function <0-7>
+#define BOARD_PDM_D1_ALTERNATE_FUNCTION                 2
 
 // <o> "PDM_D2_B" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_D2_B_GPIO_PORT                        5
+#define BOARD_PDM_D2_GPIO_PORT                          5
 // <o> "PDM_D2_B" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_D2_B_GPIO_PIN                         4
+#define BOARD_PDM_D2_GPIO_PIN                           4
+// <o> "PDM_D2_B" GPIO pin alternate function <0-7>
+#define BOARD_PDM_D2_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_D3_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_D3_A_GPIO_PORT                        5
+#define BOARD_PDM_D3_GPIO_PORT                          5
 // <o> "PDM_D3_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_D3_A_GPIO_PIN                         1
+#define BOARD_PDM_D3_GPIO_PIN                           1
+// <o> "PDM_D3_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_D3_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_C0_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_C0_A_GPIO_PORT                        0
+#define BOARD_PDM_C0_GPIO_PORT                          0
 // <o> "PDM_C0_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_C0_A_GPIO_PIN                         5
+#define BOARD_PDM_C0_GPIO_PIN                           5
+// <o> "PDM_C0_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_C0_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_C1_C" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_C1_C_GPIO_PORT                        6
-// <o> "PDM_C1_C" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
+#define BOARD_PDM_C1_GPIO_PORT                          3
+// <o> "PDM_C1_B" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_C1_C_GPIO_PIN                         3
+#define BOARD_PDM_C1_GPIO_PIN                           3
+// <o> "PDM_C1_B" GPIO pin alternate function <0-7>
+#define BOARD_PDM_C1_ALTERNATE_FUNCTION                 2
 
 // <o> "PDM_C2_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_C2_A_GPIO_PORT                        6
+#define BOARD_PDM_C2_GPIO_PORT                          6
 // <o> "PDM_C2_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_C2_A_GPIO_PIN                         7
+#define BOARD_PDM_C2_GPIO_PIN                           7
+// <o> "PDM_C2_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_C2_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_C3_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=> GPIO13
 // <14=> GPIO14 <15=> LPGPIO
-#define BOARD_PDM_C3_A_GPIO_PORT                        5
+#define BOARD_PDM_C3_GPIO_PORT                          5
 // <o> "PDM_C3_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_C3_A_GPIO_PIN                         2
+#define BOARD_PDM_C3_GPIO_PIN                           2
+// <o> "PDM_C3_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_C3_ALTERNATE_FUNCTION                 3
 
 // <o> "TOUCH_RESET" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=>
 // GPIO5 <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <10=> GPIO10 <11=> GPIO11 <12=> GPIO12 <13=>

--- a/Boards/StartKit-e1c/board_defs.h
+++ b/Boards/StartKit-e1c/board_defs.h
@@ -691,59 +691,75 @@
 
 // <o> "PDM_D0_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <15=> LPGPIO
-#define BOARD_PDM_D0_A_GPIO_PORT                        0
+#define BOARD_PDM_D0_GPIO_PORT                          0
 // <o> "PDM_D0_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_D0_A_GPIO_PIN                         4
+#define BOARD_PDM_D0_GPIO_PIN                           4
+// <o> "PDM_D0_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_D0_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_D1_C" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <15=> LPGPIO
-#define BOARD_PDM_D1_C_GPIO_PORT                        6
+#define BOARD_PDM_D1_GPIO_PORT                          6
 // <o> "PDM_D1_C" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_D1_C_GPIO_PIN                         2
+#define BOARD_PDM_D1_GPIO_PIN                           2
+// <o> "PDM_D1_C" GPIO pin alternate function <0-7>
+#define BOARD_PDM_D1_ALTERNATE_FUNCTION                 4
 
 // <o> "PDM_D2_B" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <15=> LPGPIO
-#define BOARD_PDM_D2_B_GPIO_PORT                        5
+#define BOARD_PDM_D2_GPIO_PORT                          5
 // <o> "PDM_D2_B" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_D2_B_GPIO_PIN                         4
+#define BOARD_PDM_D2_GPIO_PIN                           4
+// <o> "PDM_D2_B" GPIO pin alternate function <0-7>
+#define BOARD_PDM_D2_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_D3_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <15=> LPGPIO
-#define BOARD_PDM_D3_A_GPIO_PORT                        5
+#define BOARD_PDM_D3_GPIO_PORT                          5
 // <o> "PDM_D3_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_D3_A_GPIO_PIN                         1
+#define BOARD_PDM_D3_GPIO_PIN                           1
+// <o> "PDM_D3_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_D3_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_C0_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <15=> LPGPIO
-#define BOARD_PDM_C0_A_GPIO_PORT                        0
+#define BOARD_PDM_C0_GPIO_PORT                          0
 // <o> "PDM_C0_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_C0_A_GPIO_PIN                         5
+#define BOARD_PDM_C0_GPIO_PIN                           5
+// <o> "PDM_C0_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_C0_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_C1_C" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <15=> LPGPIO
-#define BOARD_PDM_C1_C_GPIO_PORT                        6
+#define BOARD_PDM_C1_GPIO_PORT                          6
 // <o> "PDM_C1_C" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_C1_C_GPIO_PIN                         3
+#define BOARD_PDM_C1_GPIO_PIN                           3
+// <o> "PDM_C1_C" GPIO pin alternate function <0-7>
+#define BOARD_PDM_C1_ALTERNATE_FUNCTION                 4
 
 // <o> "PDM_C2_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <15=> LPGPIO
-#define BOARD_PDM_C2_A_GPIO_PORT                        6
+#define BOARD_PDM_C2_GPIO_PORT                          6
 // <o> "PDM_C2_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_C2_A_GPIO_PIN                         7
+#define BOARD_PDM_C2_GPIO_PIN                           7
+// <o> "PDM_C2_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_C2_ALTERNATE_FUNCTION                 3
 
 // <o> "PDM_C3_A" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=> GPIO5
 // <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <15=> LPGPIO
-#define BOARD_PDM_C3_A_GPIO_PORT                        5
+#define BOARD_PDM_C3_GPIO_PORT                          5
 // <o> "PDM_C3_A" GPIO pin number <0=> PIN0 <1=> PIN1 <2=> PIN2 <3=> PIN3 <4=> PIN4 <5=> PIN5 <6=>
 // PIN6 <7=> PIN7
-#define BOARD_PDM_C3_A_GPIO_PIN                         2
+#define BOARD_PDM_C3_GPIO_PIN                           2
+// <o> "PDM_C3_A" GPIO pin alternate function <0-7>
+#define BOARD_PDM_D3_ALTERNATE_FUNCTION                 3
 
 // <o> "TOUCH_RESET" GPIO port number <0=> GPIO0 <1=> GPIO1 <2=> GPIO2 <3=> GPIO3 <4=> GPIO4 <5=>
 // GPIO5 <6=> GPIO6 <7=> GPIO7 <8=> GPIO8 <9=> GPIO9 <15=> LPGPIO

--- a/Boards/Templates/Baremetal/demo_pdm.c
+++ b/Boards/Templates/Baremetal/demo_pdm.c
@@ -169,72 +169,72 @@ static int32_t board_pdm_pins_config(void)
     int32_t status;
 
     /* channel 0_1 data line */
-    status = pinconf_set(PORT_(BOARD_PDM_D0_A_GPIO_PORT),
-                         BOARD_PDM_D0_A_GPIO_PIN,
-                         PINMUX_ALTERNATE_FUNCTION_3,
+    status = pinconf_set(PORT_(BOARD_PDM_D0_GPIO_PORT),
+                         BOARD_PDM_D0_GPIO_PIN,
+                         BOARD_PDM_D0_ALTERNATE_FUNCTION,
                          PADCTRL_READ_ENABLE);
     if (status) {
         return status;
     }
 
     /* channel 2_3 data line */
-    status = pinconf_set(PORT_(BOARD_PDM_D1_C_GPIO_PORT),
-                         BOARD_PDM_D1_C_GPIO_PIN,
-                         PINMUX_ALTERNATE_FUNCTION_4,
+    status = pinconf_set(PORT_(BOARD_PDM_D1_GPIO_PORT),
+                         BOARD_PDM_D1_GPIO_PIN,
+                         BOARD_PDM_D1_ALTERNATE_FUNCTION,
                          PADCTRL_READ_ENABLE);
     if (status) {
         return status;
     }
 
     /* channel 4_5 data line */
-    status = pinconf_set(PORT_(BOARD_PDM_D2_B_GPIO_PORT),
-                         BOARD_PDM_D2_B_GPIO_PIN,
-                         PINMUX_ALTERNATE_FUNCTION_3,
+    status = pinconf_set(PORT_(BOARD_PDM_D2_GPIO_PORT),
+                         BOARD_PDM_D2_GPIO_PIN,
+                         BOARD_PDM_D2_ALTERNATE_FUNCTION,
                          PADCTRL_READ_ENABLE);
     if (status) {
         return status;
     }
 
     /* channel 6_7 data line */
-    status = pinconf_set(PORT_(BOARD_PDM_D3_A_GPIO_PORT),
-                         BOARD_PDM_D3_A_GPIO_PIN,
-                         PINMUX_ALTERNATE_FUNCTION_3,
+    status = pinconf_set(PORT_(BOARD_PDM_D3_GPIO_PORT),
+                         BOARD_PDM_D3_GPIO_PIN,
+                         BOARD_PDM_D3_ALTERNATE_FUNCTION,
                          PADCTRL_READ_ENABLE);
     if (status) {
         return status;
     }
 
     /* Channel 0_1 clock line */
-    status = pinconf_set(PORT_(BOARD_PDM_C0_A_GPIO_PORT),
-                         BOARD_PDM_C0_A_GPIO_PIN,
-                         PINMUX_ALTERNATE_FUNCTION_3,
+    status = pinconf_set(PORT_(BOARD_PDM_C0_GPIO_PORT),
+                         BOARD_PDM_C0_GPIO_PIN,
+                         BOARD_PDM_C0_ALTERNATE_FUNCTION,
                          PADCTRL_DRIVER_DISABLED_HIGH_Z);
     if (status) {
         return status;
     }
 
     /* Channel 2_3 clock line */
-    status = pinconf_set(PORT_(BOARD_PDM_C1_C_GPIO_PORT),
-                         BOARD_PDM_C1_C_GPIO_PIN,
-                         PINMUX_ALTERNATE_FUNCTION_4,
+    status = pinconf_set(PORT_(BOARD_PDM_C1_GPIO_PORT),
+                         BOARD_PDM_C1_GPIO_PIN,
+                         BOARD_PDM_C1_ALTERNATE_FUNCTION,
                          PADCTRL_DRIVER_DISABLED_HIGH_Z);
     if (status) {
         return status;
     }
 
     /* Channel 4_5 clock line */
-    status = pinconf_set(PORT_(BOARD_PDM_C2_A_GPIO_PORT),
-                         BOARD_PDM_C2_A_GPIO_PIN,
-                         PINMUX_ALTERNATE_FUNCTION_3,
+    status = pinconf_set(PORT_(BOARD_PDM_C2_GPIO_PORT),
+                         BOARD_PDM_C2_GPIO_PIN,
+                         BOARD_PDM_C2_ALTERNATE_FUNCTION,
                          PADCTRL_DRIVER_DISABLED_HIGH_Z);
     if (status) {
         return status;
     }
 
     /* Channel 6_7 clock line */
-    status = pinconf_set(PORT_(BOARD_PDM_C3_A_GPIO_PORT),
-                         BOARD_PDM_C3_A_GPIO_PIN,
-                         PINMUX_ALTERNATE_FUNCTION_3,
+    status = pinconf_set(PORT_(BOARD_PDM_C3_GPIO_PORT),
+                         BOARD_PDM_C3_GPIO_PIN,
+                         BOARD_PDM_C3_ALTERNATE_FUNCTION,
                          PADCTRL_DRIVER_DISABLED_HIGH_Z);
     if (status) {
         return status;

--- a/Boards/Templates/FreeRTOS/demo_pdm_freertos.c
+++ b/Boards/Templates/FreeRTOS/demo_pdm_freertos.c
@@ -237,72 +237,73 @@ static int32_t board_pdm_pins_config(void)
     int32_t status;
 
     /* channel 0_1 data line */
-    status = pinconf_set(PORT_(BOARD_PDM_D0_A_GPIO_PORT),
-                         BOARD_PDM_D0_A_GPIO_PIN,
-                         PINMUX_ALTERNATE_FUNCTION_3,
+    status = pinconf_set(PORT_(BOARD_PDM_D0_GPIO_PORT),
+                         BOARD_PDM_D0_GPIO_PIN,
+                         BOARD_PDM_D0_ALTERNATE_FUNCTION,
                          PADCTRL_READ_ENABLE);
     if (status) {
         return status;
     }
 
     /* channel 2_3 data line */
-    status = pinconf_set(PORT_(BOARD_PDM_D1_C_GPIO_PORT),
-                         BOARD_PDM_D1_C_GPIO_PIN,
-                         PINMUX_ALTERNATE_FUNCTION_4,
+    status = pinconf_set(PORT_(BOARD_PDM_D1_GPIO_PORT),
+                         BOARD_PDM_D1_GPIO_PIN,
+                         BOARD_PDM_D1_ALTERNATE_FUNCTION,
                          PADCTRL_READ_ENABLE);
     if (status) {
         return status;
     }
 
     /* channel 4_5 data line */
-    status = pinconf_set(PORT_(BOARD_PDM_D2_B_GPIO_PORT),
-                         BOARD_PDM_D2_B_GPIO_PIN,
-                         PINMUX_ALTERNATE_FUNCTION_3,
+    status = pinconf_set(PORT_(BOARD_PDM_D2_GPIO_PORT),
+                         BOARD_PDM_D2_GPIO_PIN,
+                         BOARD_PDM_D2_ALTERNATE_FUNCTION,
                          PADCTRL_READ_ENABLE);
+
     if (status) {
         return status;
     }
 
     /* channel 6_7 data line */
-    status = pinconf_set(PORT_(BOARD_PDM_D3_A_GPIO_PORT),
-                         BOARD_PDM_D3_A_GPIO_PIN,
-                         PINMUX_ALTERNATE_FUNCTION_3,
+    status = pinconf_set(PORT_(BOARD_PDM_D3_GPIO_PORT),
+                         BOARD_PDM_D3_GPIO_PIN,
+                         BOARD_PDM_D3_ALTERNATE_FUNCTION,
                          PADCTRL_READ_ENABLE);
     if (status) {
         return status;
     }
 
     /* Channel 0_1 clock line */
-    status = pinconf_set(PORT_(BOARD_PDM_C0_A_GPIO_PORT),
-                         BOARD_PDM_C0_A_GPIO_PIN,
-                         PINMUX_ALTERNATE_FUNCTION_3,
+    status = pinconf_set(PORT_(BOARD_PDM_C0_GPIO_PORT),
+                         BOARD_PDM_C0_GPIO_PIN,
+                         BOARD_PDM_C0_ALTERNATE_FUNCTION,
                          PADCTRL_DRIVER_DISABLED_HIGH_Z);
     if (status) {
         return status;
     }
 
     /* Channel 2_3 clock line */
-    status = pinconf_set(PORT_(BOARD_PDM_C1_C_GPIO_PORT),
-                         BOARD_PDM_C1_C_GPIO_PIN,
-                         PINMUX_ALTERNATE_FUNCTION_4,
+    status = pinconf_set(PORT_(BOARD_PDM_C1_GPIO_PORT),
+                         BOARD_PDM_C1_GPIO_PIN,
+                         BOARD_PDM_C1_ALTERNATE_FUNCTION,
                          PADCTRL_DRIVER_DISABLED_HIGH_Z);
     if (status) {
         return status;
     }
 
     /* Channel 4_5 clock line */
-    status = pinconf_set(PORT_(BOARD_PDM_C2_A_GPIO_PORT),
-                         BOARD_PDM_C2_A_GPIO_PIN,
-                         PINMUX_ALTERNATE_FUNCTION_3,
+    status = pinconf_set(PORT_(BOARD_PDM_C2_GPIO_PORT),
+                         BOARD_PDM_C2_GPIO_PIN,
+                         BOARD_PDM_C2_ALTERNATE_FUNCTION,
                          PADCTRL_DRIVER_DISABLED_HIGH_Z);
     if (status) {
         return status;
     }
 
     /* Channel 6_7 clock line */
-    status = pinconf_set(PORT_(BOARD_PDM_C3_A_GPIO_PORT),
-                         BOARD_PDM_C3_A_GPIO_PIN,
-                         PINMUX_ALTERNATE_FUNCTION_3,
+    status = pinconf_set(PORT_(BOARD_PDM_C3_GPIO_PORT),
+                         BOARD_PDM_C3_GPIO_PIN,
+                         BOARD_PDM_C3_ALTERNATE_FUNCTION,
                          PADCTRL_DRIVER_DISABLED_HIGH_Z);
     if (status) {
         return status;


### PR DESCRIPTION
Rename the PDM pin macros in boards.def.h to use generic names
instead of instance-specific names.
update the pinmux configuration for PDM channels 2 and 3 (C1, D1) on Devkit - E8 to use the B instance.
Jira->https://alifsemi.atlassian.net/browse/PSBT-1760