### PR TITLE
drivers: can: fix CAN interrupt clearing

### DIFF
--- a/drivers/include/canfd.h
+++ b/drivers/include/canfd.h
@@ -856,9 +856,14 @@ static inline void canfd_disable_error_interrupts(CANFD_Type *canfd)
 */
 static inline void canfd_clear_interrupts(CANFD_Type *canfd)
 {
+    uint8_t temp;
+
     /* Clears data and error interrupts */
-    canfd->CANFD_RTIF    = 0U;
-    canfd->CANFD_ERRINT &= ~CANFD_ERRINT_REG_Msk;
+    canfd->CANFD_RTIF = CANFD_RTIF_REG_Msk;
+
+    temp = canfd->CANFD_ERRINT;
+    temp |= CANFD_ERRINT_REG_Msk;
+    canfd->CANFD_ERRINT = temp;
 }
 
 /**


### PR DESCRIPTION
The current implementation did not clear CANFD interrupt flags according to the HWRM-defined R/W1C behavior.

Updated the interrupt clearing logic to write 1 to the interrupt flag bits to correctly clear CANFD interrupts.