### PR TITLE
Alif_CMSIS: CPI: reset controller on stop and fix OV5675 uninit

### DIFF
--- a/Alif_CMSIS/Source/Driver_CPI.c
+++ b/Alif_CMSIS/Source/Driver_CPI.c
@@ -258,6 +258,7 @@ static int32_t CPIx_PowerControl(CPI_RESOURCES *CPI_RES,
 
             /* Reset the power status of Camera. */
             CPI_RES->status.powered = 0;
+            CPI_RES->status.sensor_configured = 0;
             break;
         }
 
@@ -423,6 +424,14 @@ static int32_t CPI_StopCapture(CPI_RESOURCES *CPI_RES)
 
     /* Stop Clear CPI control */
     cpi_stop_capture(CPI_RES->regs);
+
+    /*
+     * Issue a software reset to return the controller to a clean idle state
+     * after stopping capture.
+     */
+    CPI_RES->regs->CAM_CTRL = 0;
+    CPI_RES->regs->CAM_CTRL |= CAM_CTRL_SW_RESET;
+    CPI_RES->regs->CAM_CTRL = 0;
 
     return ARM_DRIVER_OK;
 }

--- a/components/Source/OV5675_camera_sensor.c
+++ b/components/Source/OV5675_camera_sensor.c
@@ -1161,7 +1161,10 @@ static int32_t OV5675_Uninit(void)
         return ret;
     }
 
-    return GPIO_Driver_CAM_RST->Uninitialize(BOARD_CAMERA_RESET_GPIO_PIN);
+    ret = GPIO_Driver_CAM_RST->Uninitialize(BOARD_CAMERA_RESET_GPIO_PIN);
+    if (ret != ARM_DRIVER_OK) {
+        return ret;
+    }
 
     ret = GPIO_Driver_CAM_PWR->SetValue(BOARD_CAMERA_POWER_GPIO_PIN,
                                         GPIO_PIN_OUTPUT_STATE_LOW);


### PR DESCRIPTION
- Add software reset in CPI_StopCapture() to clear stuck BUSY state.

- Clear sensor_configured in PowerControl(OFF).

- Fix early return in OV5675_Uninit() so power GPIO cleanup runs.